### PR TITLE
we only need to test the LTS release of Node

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 language: node_js
 node_js:
 - "4"
-- "5"
-- "6"
 script: "npm test && npm run lint"
 after_script: npm run coverage
 notifications:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,8 +8,6 @@ skip_tags: true
 
 environment:
   matrix:
-    - nodejs_version: '6'
-    - nodejs_version: '5'
     - nodejs_version: '4'
 
 install:


### PR DESCRIPTION
The AppVeyor takes long enough to run builds already, the fact that windows builds run in sequence means this PR speeds them up by a 3x rate.
Travis runs them in parallel and does not suffer so much on the performance, but runs linting and submits codecoverage after every build. Meaning linting is done 3 times, and codecoverage is subtmitted 3 times with no difference between them.