### PR TITLE
update npm publish script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib",
   "scripts": {
     "clean": "rimraf lib",
-    "prepublish": "npm run clean && npm run build",
+    "prepublish": "npm run clean && npm run build && gh-release",
     "preversion": "node scripts/update-compat && git add . && git commit --allow-empty -m \"chore(compat): update feature table\"",
     "postversion": "git add package.json && git commit -m \"chore(package): update version\"",
     "build": "mkdirp lib && babel src --out-dir lib",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "./lib",
   "scripts": {
     "clean": "rimraf lib",
-    "prepublish": "npm run clean && npm run build && gh-release",
+    "prepublish": "npm run clean && npm run build",
+    "postpublish": "gh-release",
     "preversion": "node scripts/update-compat && git add . && git commit --allow-empty -m \"chore(compat): update feature table\"",
     "postversion": "git add package.json && git commit -m \"chore(package): update version\"",
     "build": "mkdirp lib && babel src --out-dir lib",


### PR DESCRIPTION
Create a new github release right before publishing to npm.
This is in order for greenkeeper to include the github release in its PR's.