### PR TITLE
Refactor commands to match reply value types in ioredis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,52 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
+## [unreleased]
+
+Bumping the version to v2 as there are fixes in this release that are breaking changes.
+
+### Added
+* `flushdb` command
+
+### Changed
+* Command arguments is now transformed to strings before being passed to the command itself helping the mock behave more like a real ioredis client.
+
+### Fixed
+* `append` updated to return an integer
+* `dbsize` updated to return an integer
+* `decr` updated to return an integer
+* `decrby` updated to return an integer
+* `expire` updated to return an integer
+* `expireat` updated to return an integer
+* `hdel` updated to return an integer
+* `hexists` updated to return an integer
+* `hincrby` updated to return an integer
+* `hlen` updated to return an integer
+* `hset` updated to return an integer
+* `hsetnx` updated to return an integer
+* `hstrlen` updated to return an integer
+* `incr` updated to return an integer
+* `incrby` updated to return an integer
+* `lpush` updated to return an integer
+* `lpushx` updated to return an integer
+* `mget` required a single array argument, updated to use multiple arguments (single array support will be added later when ioredis Argument Transformers is properly implemented).
+* `msetnx` updated to return an integer
+* `persist` updated to return an integer
+* `pexpire` updated to return an integer
+* `pexpireat` updated to return an integer
+* `pttl` updated to return an integer
+* `renamenx` updated to return an integer
+* `rpush` updated to return an integer
+* `rpushx` updated to return an integer
+* `scard` updated to return an integer
+* `setnx` updated to return an integer
+* `sismember` updated to return an integer
+* `strlen` updated to return an integer
+* `ttl` updated to return an integer
+
+### Deprecated
+* `hmset` no longer accepts passing an object with keys and values directly. This will be added later when ioredis Argument Transformers is properly implemented.
+
 ## [1.15.0] - 2016-10-03
 ### Added
 * `type` command (#207)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,43 +10,43 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 Bumping the version to v2 as there are fixes in this release that are breaking changes.
 
 ### Added
-* `flushdb` command
+* `flushdb` command.
 
 ### Changed
 * Command arguments is now transformed to strings before being passed to the command itself helping the mock behave more like a real ioredis client.
 
 ### Fixed
-* `append` updated to return an integer
-* `dbsize` updated to return an integer
-* `decr` updated to return an integer
-* `decrby` updated to return an integer
-* `expire` updated to return an integer
-* `expireat` updated to return an integer
-* `hdel` updated to return an integer
-* `hexists` updated to return an integer
-* `hincrby` updated to return an integer
-* `hlen` updated to return an integer
-* `hset` updated to return an integer
-* `hsetnx` updated to return an integer
-* `hstrlen` updated to return an integer
-* `incr` updated to return an integer
-* `incrby` updated to return an integer
-* `lpush` updated to return an integer
-* `lpushx` updated to return an integer
+* `append` updated to return an integer.
+* `dbsize` updated to return an integer.
+* `decr` updated to return an integer.
+* `decrby` updated to return an integer.
+* `expire` updated to return an integer.
+* `expireat` updated to return an integer.
+* `hdel` updated to return an integer.
+* `hexists` updated to return an integer.
+* `hincrby` updated to return an integer.
+* `hlen` updated to return an integer.
+* `hset` updated to return an integer.
+* `hsetnx` updated to return an integer.
+* `hstrlen` updated to return an integer.
+* `incr` updated to return an integer.
+* `incrby` updated to return an integer.
+* `lpush` updated to return an integer.
+* `lpushx` updated to return an integer.
 * `mget` required a single array argument, updated to use multiple arguments (single array support will be added later when ioredis Argument Transformers is properly implemented).
-* `msetnx` updated to return an integer
-* `persist` updated to return an integer
-* `pexpire` updated to return an integer
-* `pexpireat` updated to return an integer
-* `pttl` updated to return an integer
-* `renamenx` updated to return an integer
-* `rpush` updated to return an integer
-* `rpushx` updated to return an integer
-* `scard` updated to return an integer
-* `setnx` updated to return an integer
-* `sismember` updated to return an integer
-* `strlen` updated to return an integer
-* `ttl` updated to return an integer
+* `msetnx` updated to return an integer.
+* `persist` updated to return an integer.
+* `pexpire` updated to return an integer.
+* `pexpireat` updated to return an integer.
+* `pttl` updated to return an integer.
+* `renamenx` updated to return an integer.
+* `rpush` updated to return an integer.
+* `rpushx` updated to return an integer.
+* `scard` updated to return an integer.
+* `setnx` updated to return an integer.
+* `sismember` updated to return an integer.
+* `strlen` updated to return an integer.
+* `ttl` updated to return an integer.
 
 ### Deprecated
 * `hmset` no longer accepts passing an object with keys and values directly. This will be added later when ioredis Argument Transformers is properly implemented.

--- a/src/command.js
+++ b/src/command.js
@@ -10,6 +10,9 @@ export default function command(emulate) {
       args.length = lastArgIndex; // eslint-disable-line no-param-reassign
     }
 
-    return new Promise(resolve => resolve(emulate(...args))).asCallback(callback);
+    // transform arguments to strings to simulate real ioredis behavior
+    const stringArgs = args.map(arg => arg.toString());
+
+    return new Promise(resolve => resolve(emulate(...stringArgs))).asCallback(callback);
   };
 }

--- a/src/commands/append.js
+++ b/src/commands/append.js
@@ -3,5 +3,5 @@ export function append(key, value) {
     this.data.set(key, '');
   }
   this.data.set(key, this.data.get(key) + value);
-  return this.data.get(key).length.toString();
+  return this.data.get(key).length;
 }

--- a/src/commands/dbsize.js
+++ b/src/commands/dbsize.js
@@ -1,3 +1,3 @@
 export function dbsize() {
-  return this.data.keys().length.toString();
+  return this.data.keys().length;
 }

--- a/src/commands/decr.js
+++ b/src/commands/decr.js
@@ -1,5 +1,6 @@
 export function decr(key) {
   const curVal = Number(this.data.get(key));
-  this.data.set(key, (curVal - 1).toString());
-  return this.data.get(key);
+  const nextVal = curVal - 1;
+  this.data.set(key, nextVal.toString());
+  return nextVal;
 }

--- a/src/commands/decrby.js
+++ b/src/commands/decrby.js
@@ -1,5 +1,6 @@
 export function decrby(key, decrement = 0) {
   const curVal = Number(this.data.get(key));
-  this.data.set(key, (curVal - decrement).toString());
-  return this.data.get(key);
+  const nextVal = curVal - parseInt(decrement, 10);
+  this.data.set(key, nextVal.toString());
+  return nextVal;
 }

--- a/src/commands/expire.js
+++ b/src/commands/expire.js
@@ -1,9 +1,9 @@
 export function expire(key, seconds) {
   if (!this.data.has(key)) {
-    return '0';
+    return 0;
   }
 
   this.expires.set(key, (seconds * 1000) + Date.now());
 
-  return '1';
+  return 1;
 }

--- a/src/commands/expireat.js
+++ b/src/commands/expireat.js
@@ -1,9 +1,9 @@
 export function expireat(key, at) {
   if (!this.data.has(key)) {
-    return '0';
+    return 0;
   }
 
   this.expires.set(key, (at * 1000));
 
-  return '1';
+  return 1;
 }

--- a/src/commands/flushdb.js
+++ b/src/commands/flushdb.js
@@ -1,0 +1,4 @@
+export function flushdb() {
+  this.data.clear();
+  return 'OK';
+}

--- a/src/commands/getrange.js
+++ b/src/commands/getrange.js
@@ -1,5 +1,7 @@
-export function getrange(key, start, end) {
+export function getrange(key, s, e) {
   const val = this.data.get(key);
+  const start = parseInt(s, 10);
+  const end = parseInt(e, 10);
 
   if (end === -1) {
     return val.slice(start);

--- a/src/commands/hdel.js
+++ b/src/commands/hdel.js
@@ -5,5 +5,5 @@ export function hdel(key, ...fields) {
       return true;
     }
     return false;
-  }).length.toString();
+  }).length;
 }

--- a/src/commands/hexists.js
+++ b/src/commands/hexists.js
@@ -1,3 +1,3 @@
 export function hexists(key, field) {
-  return {}.hasOwnProperty.call(this.data.get(key), field) ? '1' : '0';
+  return {}.hasOwnProperty.call(this.data.get(key), field) ? 1 : 0;
 }

--- a/src/commands/hincrby.js
+++ b/src/commands/hincrby.js
@@ -1,11 +1,12 @@
 export function hincrby(key, field, increment = 0) {
   if (!this.data.has(key)) {
-    this.data.set(key, { [field]: 0 });
+    this.data.set(key, { [field]: '0' });
   }
   if (!{}.hasOwnProperty.call(this.data.get(key), field)) {
-    this.data.get(key)[field] = 0;
+    this.data.get(key)[field] = '0';
   }
   const curVal = Number(this.data.get(key)[field]);
-  this.data.get(key)[field] = curVal + increment;
-  return this.data.get(key)[field].toString();
+  const nextVal = curVal + parseInt(increment, 10);
+  this.data.get(key)[field] = nextVal.toString();
+  return nextVal;
 }

--- a/src/commands/hincrbyfloat.js
+++ b/src/commands/hincrbyfloat.js
@@ -1,9 +1,9 @@
 export function hincrbyfloat(key, field, increment) {
   if (!this.data.has(key)) {
-    this.data.set(key, { [field]: 0 });
+    this.data.set(key, { [field]: '0' });
   }
   if (!{}.hasOwnProperty.call(this.data.get(key), field)) {
-    this.data.get(key)[field] = 0;
+    this.data.get(key)[field] = '0';
   }
   const curVal = parseFloat(this.data.get(key)[field]);
   this.data.get(key)[field] = (curVal + parseFloat(increment)).toString();

--- a/src/commands/hlen.js
+++ b/src/commands/hlen.js
@@ -1,3 +1,3 @@
 export function hlen(key) {
-  return this.data.has(key) ? Object.keys(this.data.get(key)).length.toString() : '0';
+  return this.data.has(key) ? Object.keys(this.data.get(key)).length : 0;
 }

--- a/src/commands/hmset.js
+++ b/src/commands/hmset.js
@@ -1,18 +1,10 @@
-import objectAssign from 'object-assign';
-
 export function hmset(key, ...hmsetData) {
   if (!this.data.has(key)) {
     this.data.set(key, {});
   }
 
-  if (hmsetData.length === 1) {
-    // assume object
-    this.data.set(key, objectAssign({}, hmsetData[0]));
-  } else {
-    // assume array
-    for (let i = 0; i < hmsetData.length; i += 2) {
-      this.data.get(key)[hmsetData[i]] = hmsetData[i + 1];
-    }
+  for (let i = 0; i < hmsetData.length; i += 2) {
+    this.data.get(key)[hmsetData[i]] = hmsetData[i + 1];
   }
 
   return 'OK';

--- a/src/commands/hset.js
+++ b/src/commands/hset.js
@@ -3,11 +3,11 @@ export function hset(key, hashKey, hashVal) {
     this.data.set(key, {});
   }
 
-  let reply = '1';
+  let reply = 1;
   const hash = this.data.get(key);
 
   if ({}.hasOwnProperty.call(hash, hashKey)) {
-    reply = '0';
+    reply = 0;
   }
 
   hash[hashKey] = hashVal;

--- a/src/commands/hsetnx.js
+++ b/src/commands/hsetnx.js
@@ -6,8 +6,8 @@ export function hsetnx(key, hashKey, hashVal) {
   if (!{}.hasOwnProperty.call(this.data.get(key), hashKey)) {
     this.data.get(key)[hashKey] = hashVal;
 
-    return '1';
+    return 1;
   }
 
-  return '0';
+  return 0;
 }

--- a/src/commands/hstrlen.js
+++ b/src/commands/hstrlen.js
@@ -1,4 +1,4 @@
 export function hstrlen(key, field) {
   return (this.data.has(key) && {}.hasOwnProperty.call(this.data.get(key), field)) ?
-         this.data.get(key)[field].length.toString() : '0';
+         this.data.get(key)[field].length : 0;
 }

--- a/src/commands/incr.js
+++ b/src/commands/incr.js
@@ -3,6 +3,7 @@ export function incr(key) {
     this.data.set(key, '0');
   }
   const curVal = Number(this.data.get(key));
-  this.data.set(key, (curVal + 1).toString());
-  return this.data.get(key);
+  const nextVal = curVal + 1;
+  this.data.set(key, nextVal.toString());
+  return nextVal;
 }

--- a/src/commands/incrby.js
+++ b/src/commands/incrby.js
@@ -1,5 +1,6 @@
 export function incrby(key, increment = 0) {
   const curVal = Number(this.data.get(key));
-  this.data.set(key, (curVal + increment).toString());
-  return this.data.get(key);
+  const nextVal = curVal + parseInt(increment, 10);
+  this.data.set(key, nextVal.toString());
+  return nextVal;
 }

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -13,6 +13,7 @@ export * from './exists';
 export * from './expire';
 export * from './expireat';
 export * from './flushall';
+export * from './flushdb';
 export * from './get';
 export * from './getrange';
 export * from './getset';

--- a/src/commands/lindex.js
+++ b/src/commands/lindex.js
@@ -1,7 +1,8 @@
-export function lindex(key, index) {
+export function lindex(key, i) {
   if (this.data.has(key) && !(this.data.get(key) instanceof Array)) {
     throw new Error(`Key ${key} does not contain a list`);
   }
+  const index = parseInt(i, 10);
   const list = this.data.get(key) || [];
   const item = list[index < 0 ? list.length + index : index];
   return item !== undefined ? item : null;

--- a/src/commands/lpush.js
+++ b/src/commands/lpush.js
@@ -5,5 +5,5 @@ export function lpush(key, ...values) {
   const list = this.data.get(key) || [];
   const length = list.unshift(...values.reverse());
   this.data.set(key, list);
-  return length.toString();
+  return length;
 }

--- a/src/commands/lpushx.js
+++ b/src/commands/lpushx.js
@@ -2,7 +2,7 @@ import { lpush } from './index';
 
 export function lpushx(key, value) {
   if (!this.data.has(key)) {
-    return '0';
+    return 0;
   }
 
   return lpush.call(this, key, value);

--- a/src/commands/lrem.js
+++ b/src/commands/lrem.js
@@ -1,7 +1,8 @@
-export function lrem(key, count, value) {
+export function lrem(key, c, value) {
   if (this.data.has(key) && !(this.data.get(key) instanceof Array)) {
     return 0;
   }
+  const count = parseInt(c, 10);
   const list = [...(this.data.get(key) || [])];
   const indexFun = (count < 0 ? [].lastIndexOf : [].indexOf).bind(list);
   const max = count === 0 ? list.length : Math.abs(count);

--- a/src/commands/lset.js
+++ b/src/commands/lset.js
@@ -1,4 +1,4 @@
-export function lset(key, index, value) {
+export function lset(key, i, value) {
   if (!this.data.has(key)) {
     throw new Error('no such key');
   }
@@ -7,6 +7,7 @@ export function lset(key, index, value) {
     throw new Error(`Key ${key} does not contain a list`);
   }
 
+  const index = parseInt(i, 10);
   const list = this.data.get(key) || [];
   list[index < 0 ? list.length + index : index] = value;
   return 'OK';

--- a/src/commands/mget.js
+++ b/src/commands/mget.js
@@ -1,3 +1,3 @@
-export function mget(keys) {
+export function mget(...keys) {
   return keys.map(key => (this.data.has(key) ? this.data.get(key) : null));
 }

--- a/src/commands/msetnx.js
+++ b/src/commands/msetnx.js
@@ -3,7 +3,7 @@ import { set } from './index';
 export function msetnx(...msetData) {
   for (let i = 0; i < msetData.length; i += 2) {
     if (this.data.has(msetData[i])) {
-      return '0';
+      return 0;
     }
   }
 
@@ -11,5 +11,5 @@ export function msetnx(...msetData) {
     set.call(this, msetData[i], msetData[i + 1]);
   }
 
-  return '1';
+  return 1;
 }

--- a/src/commands/persist.js
+++ b/src/commands/persist.js
@@ -1,13 +1,13 @@
 export function persist(key) {
   if (!this.data.has(key)) {
-    return '0';
+    return 0;
   }
 
   if (!this.expires.has(key)) {
-    return '0';
+    return 0;
   }
 
   this.expires.delete(key);
 
-  return '1';
+  return 1;
 }

--- a/src/commands/pexpire.js
+++ b/src/commands/pexpire.js
@@ -1,9 +1,9 @@
 export function pexpire(key, milliseconds) {
   if (!this.data.has(key)) {
-    return '0';
+    return 0;
   }
 
   this.expires.set(key, milliseconds + Date.now());
 
-  return '1';
+  return 1;
 }

--- a/src/commands/pexpireat.js
+++ b/src/commands/pexpireat.js
@@ -1,9 +1,9 @@
 export function pexpireat(key, at) {
   if (!this.data.has(key)) {
-    return '0';
+    return 0;
   }
 
   this.expires.set(key, at);
 
-  return '1';
+  return 1;
 }

--- a/src/commands/pttl.js
+++ b/src/commands/pttl.js
@@ -1,11 +1,11 @@
 export function pttl(key) {
   if (!this.data.has(key)) {
-    return '-2';
+    return -2;
   }
 
   if (!this.expires.has(key)) {
-    return '-1';
+    return -1;
   }
 
-  return Math.round((this.expires.get(key) - Date.now())).toString();
+  return Math.ceil((this.expires.get(key) - Date.now()));
 }

--- a/src/commands/renamenx.js
+++ b/src/commands/renamenx.js
@@ -2,10 +2,10 @@ import { rename } from './index';
 
 export function renamenx(key, newKey) {
   if (this.data.has(newKey)) {
-    return '0';
+    return 0;
   }
 
   rename.call(this, key, newKey);
 
-  return '1';
+  return 1;
 }

--- a/src/commands/rpush.js
+++ b/src/commands/rpush.js
@@ -5,5 +5,5 @@ export function rpush(key, ...values) {
   const list = this.data.get(key) || [];
   const length = list.push(...values);
   this.data.set(key, list);
-  return length.toString();
+  return length;
 }

--- a/src/commands/rpushx.js
+++ b/src/commands/rpushx.js
@@ -2,7 +2,7 @@ import { rpush } from './index';
 
 export function rpushx(key, value) {
   if (!this.data.has(key)) {
-    return '0';
+    return 0;
   }
 
   return rpush.call(this, key, value);

--- a/src/commands/scard.js
+++ b/src/commands/scard.js
@@ -3,10 +3,10 @@ import Set from 'es6-set';
 export function scard(key) {
   const set = this.data.get(key);
   if (!set) {
-    return '0';
+    return 0;
   }
   if (!(set instanceof Set)) {
     throw new Error(`Key ${key} does not contain a set`);
   }
-  return this.data.get(key).size.toString();
+  return this.data.get(key).size;
 }

--- a/src/commands/setnx.js
+++ b/src/commands/setnx.js
@@ -2,8 +2,8 @@ export function setnx(key, val) {
   if (!this.data.has(key)) {
     this.data.set(key, val);
 
-    return '1';
+    return 1;
   }
 
-  return '0';
+  return 0;
 }

--- a/src/commands/sismember.js
+++ b/src/commands/sismember.js
@@ -1,3 +1,3 @@
 export function sismember(key, val) {
-  return this.data.get(key).has(val);
+  return this.data.get(key).has(val) ? 1 : 0;
 }

--- a/src/commands/strlen.js
+++ b/src/commands/strlen.js
@@ -1,3 +1,3 @@
 export function strlen(key) {
-  return this.data.has(key) ? this.data.get(key).length.toString() : '0';
+  return this.data.has(key) ? this.data.get(key).length : 0;
 }

--- a/src/commands/ttl.js
+++ b/src/commands/ttl.js
@@ -1,11 +1,11 @@
 export function ttl(key) {
   if (!this.data.has(key)) {
-    return '-2';
+    return -2;
   }
 
   if (!this.expires.has(key)) {
-    return '-1';
+    return -1;
   }
 
-  return Math.round((this.expires.get(key) - Date.now()) / 1000).toString();
+  return Math.ceil((this.expires.get(key) - Date.now()) / 1000);
 }

--- a/test/commands/append.js
+++ b/test/commands/append.js
@@ -10,13 +10,13 @@ describe('append', () => {
       },
     });
 
-    return redis.append('mykey', ' World').then(newLength => expect(newLength).toBe('11'))
+    return redis.append('mykey', ' World').then(newLength => expect(newLength).toBe(11))
       .then(() => expect(redis.data.get('mykey')).toBe('Hello World'));
   });
   it('should set empty string if key does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.append('mykey', ' World').then(newLength => expect(newLength).toBe('6'))
+    return redis.append('mykey', ' World').then(newLength => expect(newLength).toBe(6))
       .then(() => expect(redis.data.get('mykey')).toBe(' World'));
   });
 });

--- a/test/commands/dbsize.js
+++ b/test/commands/dbsize.js
@@ -12,6 +12,6 @@ describe('dbsize', () => {
     });
 
     return redis.dbsize()
-      .then(result => expect(result).toBe('2'));
+      .then(result => expect(result).toBe(2));
   });
 });

--- a/test/commands/decr.js
+++ b/test/commands/decr.js
@@ -10,6 +10,8 @@ describe('decr', () => {
       },
     });
 
-    return redis.decr('user_next').then(userNext => expect(userNext).toBe('1'));
+    return redis.decr('user_next')
+      .then(userNext => expect(userNext).toBe(1))
+      .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
 });

--- a/test/commands/decrby.js
+++ b/test/commands/decrby.js
@@ -10,7 +10,9 @@ describe('decrby', () => {
       },
     });
 
-    return redis.decrby('user_next', 10).then(userNext => expect(userNext).toBe('1'));
+    return redis.decrby('user_next', 10)
+      .then(userNext => expect(userNext).toBe(1))
+      .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
   it('should not increment if no increment is passed', () => {
     const redis = new MockRedis({
@@ -19,6 +21,8 @@ describe('decrby', () => {
       },
     });
 
-    return redis.decrby('user_next').then(userNext => expect(userNext).toBe('1'));
+    return redis.decrby('user_next')
+      .then(userNext => expect(userNext).toBe(1))
+      .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
 });

--- a/test/commands/expire.js
+++ b/test/commands/expire.js
@@ -15,7 +15,7 @@ describe('expire', () => {
       redis.get('foo'),
       Promise.delay(1000).then(() => redis.get('foo')),
     ]).then(([status, beforeExpire, afterExpire]) => {
-      expect(status).toBe('1');
+      expect(status).toBe(1);
       expect(beforeExpire).toBe('bar');
       expect(afterExpire).toBe(null);
       expect(redis.data.has('foo')).toBe(false);
@@ -33,7 +33,7 @@ describe('expire', () => {
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
-    return redis.expire('foo', 1).then(status => expect(status).toBe('0'));
+    return redis.expire('foo', 1).then(status => expect(status).toBe(0));
   });
 
   it('should remove expire on SET', () => {

--- a/test/commands/expireat.js
+++ b/test/commands/expireat.js
@@ -11,16 +11,16 @@ describe('expireat', () => {
     });
     const at = Math.ceil(Date.now() / 1000) + 1;
     return redis.expireat('foo', at).then((status) => {
-      expect(status).toBe('1');
+      expect(status).toBe(1);
       expect(redis.expires.has('foo')).toBe(true);
 
       return redis.ttl('foo');
-    }).then(result => expect(parseInt(result, 10)).toBeGreaterThanOrEqualTo(1));
+    }).then(result => expect(result).toBeGreaterThanOrEqualTo(1));
   });
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
     const at = Math.ceil(Date.now() / 1000);
-    return redis.expireat('foo', at).then(status => expect(status).toBe('0'));
+    return redis.expireat('foo', at).then(status => expect(status).toBe(0));
   });
 });

--- a/test/commands/flushall.js
+++ b/test/commands/flushall.js
@@ -9,8 +9,9 @@ describe('flushall', () => {
       metoo: 'pretty please',
     },
   });
-  it('should empty db', () =>
+  it('should empty current db', () =>
     redis.flushall().then(status => expect(status).toBe('OK'))
       .then(() => expect(redis.data.keys().length).toBe(0))
   );
+  it('should empty every db');
 });

--- a/test/commands/flushdb.js
+++ b/test/commands/flushdb.js
@@ -1,0 +1,17 @@
+import expect from 'expect';
+
+import MockRedis from '../../src';
+
+describe('flushdb', () => {
+  const redis = new MockRedis({
+    data: {
+      deleteme: 'please',
+      metoo: 'pretty please',
+    },
+  });
+  it('should empty current db', () =>
+    redis.flushdb().then(status => expect(status).toBe('OK'))
+      .then(() => expect(redis.data.keys().length).toBe(0))
+  );
+  it('should empty other db after SELECT');
+});

--- a/test/commands/hdel.js
+++ b/test/commands/hdel.js
@@ -9,7 +9,7 @@ describe('hdel', () => {
     },
   });
   it('should delete passed in keys from hash map', () =>
-    redis.hdel('user:1', 'id', 'email', 'location').then(status => expect(status).toBe('2'))
+    redis.hdel('user:1', 'id', 'email', 'location').then(status => expect(status).toBe(2))
       .then(() => expect(redis.data.get('user:1')).toEqual({ name: 'Bruce Wayne' }))
   );
 });

--- a/test/commands/hexists.js
+++ b/test/commands/hexists.js
@@ -9,9 +9,9 @@ describe('hexists', () => {
     },
   });
   it('should return 1 if key exists in hash map', () =>
-    redis.hexists('foo', 'bar').then(status => expect(status).toBe('1'))
+    redis.hexists('foo', 'bar').then(status => expect(status).toBe(1))
   );
   it('should return 0 if key not exists in hash map', () =>
-    redis.hexists('foo', 'baz').then(status => expect(status).toBe('0'))
+    redis.hexists('foo', 'baz').then(status => expect(status).toBe(0))
   );
 });

--- a/test/commands/hincrby.js
+++ b/test/commands/hincrby.js
@@ -12,14 +12,16 @@ describe('hincrby', () => {
       },
     });
 
-    return redis.hincrby('highscores', 'user:1', 100).then(
-      highscore => expect(highscore).toBe('9100', 'over 9000!')
-    );
+    return redis.hincrby('highscores', 'user:1', 100)
+      .then(result => expect(result).toBe(9100))
+      .then(() => expect(redis.data.get('highscores')['user:1']).toBe('9100'));
   });
   it('should create hash if not exists', () => {
     const redis = new MockRedis();
 
-    return redis.hincrby('stats', 'hits', 100).then(userNext => expect(userNext).toBe('100'));
+    return redis.hincrby('stats', 'hits', 100)
+      .then(result => expect(result).toBe(100))
+      .then(() => expect(redis.data.get('stats').hits).toBe('100'));
   });
   it('should create field in hash if not exists', () => {
     const redis = new MockRedis({
@@ -28,7 +30,9 @@ describe('hincrby', () => {
       },
     });
 
-    return redis.hincrby('stats', 'hits', 100).then(userNext => expect(userNext).toBe('100'));
+    return redis.hincrby('stats', 'hits', 100)
+      .then(result => expect(result).toBe(100))
+      .then(() => expect(redis.data.get('stats').hits).toBe('100'));
   });
   it('should decrement value in hash if negative integer is passed', () => {
     const redis = new MockRedis({
@@ -39,8 +43,8 @@ describe('hincrby', () => {
       },
     });
 
-    return redis.hincrby('highscores', 'user:1', -100).then(
-      userNext => expect(userNext).toBe('8900')
-    );
+    return redis.hincrby('highscores', 'user:1', -100)
+      .then(result => expect(result).toBe(8900))
+      .then(() => expect(redis.data.get('highscores')['user:1']).toBe('8900'));
   });
 });

--- a/test/commands/hincrbyfloat.js
+++ b/test/commands/hincrbyfloat.js
@@ -13,7 +13,8 @@ describe('hincrbyfloat', () => {
     return redis.hincrbyfloat('mykey', 'field', 0.1)
       .then(result => expect(result).toBe('10.6'))
       .then(() => redis.hincrbyfloat('mykey', 'field', -5))
-      .then(result => expect(result).toBe('5.6'));
+      .then(result => expect(result).toBe('5.6'))
+      .then(() => expect(redis.data.get('mykey').field).toBe('5.6'));
   });
 
   it('should support exponents', () => {
@@ -24,13 +25,16 @@ describe('hincrbyfloat', () => {
     });
 
     return redis.hincrbyfloat('mykey', 'field', '2.0e2')
-      .then(result => expect(result).toBe('5200'));
+      .then(result => expect(result).toBe('5200'))
+      .then(() => expect(redis.data.get('mykey').field).toBe('5200'));
   });
 
   it('should create hash if not exists', () => {
     const redis = new MockRedis();
 
-    return redis.hincrbyfloat('stats', 'health', 0.5).then(result => expect(result).toBe('0.5'));
+    return redis.hincrbyfloat('stats', 'health', 0.5)
+      .then(result => expect(result).toBe('0.5'))
+      .then(() => expect(redis.data.get('stats').health).toBe('0.5'));
   });
 
   it('should create field in hash if not exists', () => {
@@ -40,6 +44,8 @@ describe('hincrbyfloat', () => {
       },
     });
 
-    return redis.hincrbyfloat('stats', 'health', 0.5).then(result => expect(result).toBe('0.5'));
+    return redis.hincrbyfloat('stats', 'health', 0.5)
+      .then(result => expect(result).toBe('0.5'))
+      .then(() => expect(redis.data.get('stats').health).toBe('0.5'));
   });
 });

--- a/test/commands/hlen.js
+++ b/test/commands/hlen.js
@@ -6,7 +6,7 @@ describe('hlen', () => {
   it('should return an empty array if there are no keys', () => {
     const redis = new MockRedis();
 
-    return redis.hlen('foo').then(result => expect(result).toBe('0'));
+    return redis.hlen('foo').then(result => expect(result).toBe(0));
   });
 
   it('should return all data keys', () => {
@@ -16,6 +16,6 @@ describe('hlen', () => {
       },
     });
 
-    return redis.hlen('foo').then(result => expect(result).toEqual('2'));
+    return redis.hlen('foo').then(result => expect(result).toEqual(2));
   });
 });

--- a/test/commands/hmset.js
+++ b/test/commands/hmset.js
@@ -11,11 +11,11 @@ describe('hmset', () => {
       .then(() => expect(redis.data.get('user:1')).toEqual(hash));
   });
 
-  it('should let you set multiple hash map keys and values with an object', () => {
+  it('should let you set multiple hash map keys and values with an object'/* , () => {
     const redis = new MockRedis();
     const hash = { id: '1', email: 'bruce@wayne.enterprises' };
     return redis.hmset('user:1', hash)
       .then(status => expect(status).toBe('OK'))
       .then(() => expect(redis.data.get('user:1')).toEqual(hash));
-  });
+  }*/);
 });

--- a/test/commands/hset.js
+++ b/test/commands/hset.js
@@ -7,13 +7,13 @@ describe('hset', () => {
 
   it('should return 1 when setting a new field', () =>
     redis.hset('user:1', 'email', 'clark@daily.planet')
-      .then(status => expect(status).toBe('1'))
+      .then(status => expect(status).toBe(1))
       .then(() => expect(redis.data.get('user:1')).toEqual({ email: 'clark@daily.planet' }))
   );
 
   it('should return 0 when overwriting existing field', () =>
     redis.hset('user:1', 'email', 'bruce@wayne.enterprises')
-      .then(status => expect(status).toBe('0'))
+      .then(status => expect(status).toBe(0))
       .then(() => expect(redis.data.get('user:1')).toEqual({ email: 'bruce@wayne.enterprises' }))
   );
 });

--- a/test/commands/hsetnx.js
+++ b/test/commands/hsetnx.js
@@ -6,13 +6,13 @@ describe('hsetnx', () => {
   it('should set a key in a hash map if it does not exist already', () => {
     const redis = new MockRedis();
     return redis.hsetnx('emails', 'bruce@wayne.enterprises', '1')
-      .then(status => expect(status).toBe('1'))
+      .then(status => expect(status).toBe(1))
       .then(() => {
         expect(redis.data.get('emails')['bruce@wayne.enterprises'])
           .toBe('1', 'hash map value failed to persist');
         return redis.hsetnx('emails', 'bruce@wayne.enterprises', '2');
       })
-      .then(status => expect(status).toBe('0', 'hsetnx no-op failed on existing key'))
+      .then(status => expect(status).toBe(0, 'hsetnx no-op failed on existing key'))
       .then(() => {
         expect(redis.data.get('emails')['bruce@wayne.enterprises'])
           .toBe('1', 'existing hash map value was overwritten');

--- a/test/commands/hstrlen.js
+++ b/test/commands/hstrlen.js
@@ -6,13 +6,13 @@ describe('hstrlen', () => {
   it('should return 0 on keys that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.hstrlen('nonexisting').then(result => expect(result).toBe('0'));
+    return redis.hstrlen('nonexisting').then(result => expect(result).toBe(0));
   });
 
   it('should return 0 on fields that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.hstrlen('nonexisting', 'foo').then(result => expect(result).toBe('0'));
+    return redis.hstrlen('nonexisting', 'foo').then(result => expect(result).toBe(0));
   });
 
   it('should return length on existing fields', () => {
@@ -24,6 +24,6 @@ describe('hstrlen', () => {
       },
     });
 
-    return redis.hstrlen('mykey', 'foo').then(result => expect(result).toBe('11'));
+    return redis.hstrlen('mykey', 'foo').then(result => expect(result).toBe(11));
   });
 });

--- a/test/commands/incr.js
+++ b/test/commands/incr.js
@@ -10,12 +10,16 @@ describe('incr', () => {
       },
     });
 
-    return redis.incr('user_next').then(userNext => expect(userNext).toBe('2'));
+    return redis.incr('user_next')
+      .then(userNext => expect(userNext).toBe(2))
+      .then(() => expect(redis.data.get('user_next')).toBe('2'));
   });
 
   it('should set default value if not exists', () => {
     const redis = new MockRedis();
 
-    return redis.incr('user_next').then(userNext => expect(userNext).toBe('1'));
+    return redis.incr('user_next')
+      .then(userNext => expect(userNext).toBe(1))
+      .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
 });

--- a/test/commands/incrby.js
+++ b/test/commands/incrby.js
@@ -10,7 +10,9 @@ describe('incrby', () => {
       },
     });
 
-    return redis.incrby('user_next', 10).then(userNext => expect(userNext).toBe('11'));
+    return redis.incrby('user_next', 10)
+      .then(userNext => expect(userNext).toBe(11))
+      .then(() => expect(redis.data.get('user_next')).toBe('11'));
   });
   it('should not increment if no increment is passed', () => {
     const redis = new MockRedis({
@@ -19,6 +21,8 @@ describe('incrby', () => {
       },
     });
 
-    return redis.incrby('user_next').then(userNext => expect(userNext).toBe('1'));
+    return redis.incrby('user_next')
+      .then(userNext => expect(userNext).toBe(1))
+      .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
 });

--- a/test/commands/incrbyfloat.js
+++ b/test/commands/incrbyfloat.js
@@ -13,7 +13,8 @@ describe('incrbyfloat', () => {
     return redis.incrbyfloat('mykey', 0.1)
       .then(result => expect(result).toBe('10.6'))
       .then(() => redis.incrbyfloat('mykey', -5))
-      .then(result => expect(result).toBe('5.6'));
+      .then(result => expect(result).toBe('5.6'))
+      .then(() => expect(redis.data.get('mykey')).toBe('5.6'));
   });
 
   it('should support exponents', () => {
@@ -23,6 +24,8 @@ describe('incrbyfloat', () => {
       },
     });
 
-    return redis.incrbyfloat('mykey', '2.0e2').then(result => expect(result).toBe('5200'));
+    return redis.incrbyfloat('mykey', '2.0e2')
+      .then(result => expect(result).toBe('5200'))
+      .then(() => expect(redis.data.get('mykey')).toBe('5200'));
   });
 });

--- a/test/commands/llen.js
+++ b/test/commands/llen.js
@@ -6,7 +6,7 @@ describe('llen', () => {
   it('should return the number of items in the list', () => {
     const redis = new MockRedis({
       data: {
-        foo: [1, 3, 4],
+        foo: ['1', '3', '4'],
       },
     });
 

--- a/test/commands/lpop.js
+++ b/test/commands/lpop.js
@@ -6,13 +6,13 @@ describe('lpop', () => {
   it('should remove and return first element of list', () => {
     const redis = new MockRedis({
       data: {
-        foo: [3, 2, 1],
+        foo: ['3', '2', '1'],
       },
     });
 
     return redis.lpop('foo')
-      .then(result => expect(result).toBe(3))
-      .then(() => expect(redis.data.get('foo')).toEqual([2, 1]));
+      .then(result => expect(result).toBe('3'))
+      .then(() => expect(redis.data.get('foo')).toEqual(['2', '1']));
   });
 
   it('should return null on empty list', () => {

--- a/test/commands/lpush.js
+++ b/test/commands/lpush.js
@@ -6,12 +6,12 @@ describe('lpush', () => {
   it('should add the values to the list in the correct order', () => {
     const redis = new MockRedis({
       data: {
-        foo: [1],
+        foo: ['1'],
       },
     });
 
     return redis.lpush('foo', 9, 8, 7)
-      .then(() => expect(redis.data.get('foo')).toEqual([7, 8, 9, 1]));
+      .then(() => expect(redis.data.get('foo')).toEqual(['7', '8', '9', '1']));
   });
 
   it('should return the new length of the list', () => {
@@ -20,7 +20,7 @@ describe('lpush', () => {
       },
     });
 
-    return redis.lpush('foo', 9, 8, 7).then(length => expect(length).toBe('3'));
+    return redis.lpush('foo', 9, 8, 7).then(length => expect(length).toBe(3));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {

--- a/test/commands/lpushx.js
+++ b/test/commands/lpushx.js
@@ -6,27 +6,27 @@ describe('lpushx', () => {
   it('should add the values to the list in the correct order', () => {
     const redis = new MockRedis({
       data: {
-        foo: [2],
+        foo: ['2'],
       },
     });
 
     return redis.lpushx('foo', 1)
-      .then(() => expect(redis.data.get('foo')).toEqual([1, 2]));
+      .then(() => expect(redis.data.get('foo')).toEqual(['1', '2']));
   });
 
   it('should return the new length of the list', () => {
     const redis = new MockRedis({
       data: {
-        foo: [2],
+        foo: ['2'],
       },
     });
 
-    return redis.lpushx('foo', 1).then(result => expect(result).toBe('2'));
+    return redis.lpushx('foo', 1).then(result => expect(result).toBe(2));
   });
 
   it('should return 0 if list does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.lpushx('foo', 1).then(result => expect(result).toBe('0'));
+    return redis.lpushx('foo', 1).then(result => expect(result).toBe(0));
   });
 });

--- a/test/commands/mget.js
+++ b/test/commands/mget.js
@@ -6,7 +6,7 @@ describe('mget', () => {
   it('should return null on keys that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.mget(['foo']).then(result => expect(result).toEqual([null]));
+    return redis.mget('foo').then(result => expect(result).toEqual([null]));
   });
 
   it('should return value keys that exist', () => {
@@ -16,6 +16,6 @@ describe('mget', () => {
       },
     });
 
-    return redis.mget(['foo', 'hello']).then(result => expect(result).toEqual(['bar', null]));
+    return redis.mget('foo', 'hello').then(result => expect(result).toEqual(['bar', null]));
   });
 });

--- a/test/commands/msetnx.js
+++ b/test/commands/msetnx.js
@@ -6,7 +6,7 @@ describe('msetnx', () => {
   it('should batch set values', () => {
     const redis = new MockRedis();
     return redis.msetnx('key1', 'Hello', 'key2', 'World')
-      .then(status => expect(status).toBe('1'))
+      .then(status => expect(status).toBe(1))
       .then(() => {
         expect(redis.data.get('key1')).toBe('Hello');
         expect(redis.data.get('key2')).toBe('World');
@@ -20,7 +20,7 @@ describe('msetnx', () => {
       },
     });
     return redis.msetnx('key1', 'Hello', 'key2', 'World')
-      .then(status => expect(status).toBe('0'))
+      .then(status => expect(status).toBe(0))
       .then(() => {
         expect(redis.data.get('key1')).toBe('Nope');
         expect(redis.data.has('key2')).toBe(false);

--- a/test/commands/persist.js
+++ b/test/commands/persist.js
@@ -12,7 +12,7 @@ describe('persist', () => {
     return redis.expire('foo', 1)
       .then(() => redis.persist('foo'))
       .then((status) => {
-        expect(status).toBe('1');
+        expect(status).toBe(1);
         expect(redis.expires.has('foo')).toBe(false);
       });
   });
@@ -23,12 +23,12 @@ describe('persist', () => {
         foo: 'bar',
       },
     });
-    return redis.persist('foo').then(status => expect(status).toBe('0'));
+    return redis.persist('foo').then(status => expect(status).toBe(0));
   });
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.persist('foo').then(status => expect(status).toBe('0'));
+    return redis.persist('foo').then(status => expect(status).toBe(0));
   });
 });

--- a/test/commands/pexpire.js
+++ b/test/commands/pexpire.js
@@ -10,15 +10,15 @@ describe('pexpire', () => {
       },
     });
     return redis.pexpire('foo', 100).then((status) => {
-      expect(status).toBe('1');
+      expect(status).toBe(1);
       expect(redis.expires.has('foo')).toBe(true);
 
       return redis.pttl('foo');
-    }).then(result => expect(parseInt(result, 10)).toBeGreaterThanOrEqualTo(1));
+    }).then(result => expect(result).toBeGreaterThanOrEqualTo(1));
   });
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
-    return redis.pexpire('foo', 100).then(status => expect(status).toBe('0'));
+    return redis.pexpire('foo', 100).then(status => expect(status).toBe(0));
   });
 });

--- a/test/commands/pexpireat.js
+++ b/test/commands/pexpireat.js
@@ -11,16 +11,16 @@ describe('pexpireat', () => {
     });
     const at = Date.now() + 2000;
     return redis.pexpireat('foo', at).then((status) => {
-      expect(status).toBe('1');
+      expect(status).toBe(1);
       expect(redis.expires.has('foo')).toBe(true);
 
       return redis.ttl('foo');
-    }).then(result => expect(parseInt(result, 10)).toBeGreaterThanOrEqualTo(1));
+    }).then(result => expect(result).toBeGreaterThanOrEqualTo(1));
   });
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
     const at = Date.now();
-    return redis.pexpireat('foo', at).then(status => expect(status).toBe('0'));
+    return redis.pexpireat('foo', at).then(status => expect(status).toBe(0));
   });
 });

--- a/test/commands/pttl.js
+++ b/test/commands/pttl.js
@@ -6,7 +6,7 @@ describe('pttl', () => {
   it('should return -2 if key does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.pttl('foo').then(result => expect(result).toBe('-2'));
+    return redis.pttl('foo').then(result => expect(result).toBe(-2));
   });
 
   it('should return -1 if key exist but have no expire', () => {
@@ -16,7 +16,7 @@ describe('pttl', () => {
       },
     });
 
-    return redis.pttl('foo').then(result => expect(result).toBe('-1'));
+    return redis.pttl('foo').then(result => expect(result).toBe(-1));
   });
 
   it('should return seconds left until expire', () => {
@@ -27,6 +27,6 @@ describe('pttl', () => {
     });
 
     return redis.expire('foo', 1).then(() => redis.pttl('foo'))
-      .then(result => expect(parseInt(result, 10)).toBeGreaterThan(0));
+      .then(result => expect(result).toBeGreaterThan(0));
   });
 });

--- a/test/commands/renamenx.js
+++ b/test/commands/renamenx.js
@@ -9,7 +9,7 @@ describe('renamenx', () => {
         foo: 'baz',
       },
     });
-    return redis.renamenx('foo', 'bar').then(status => expect(status).toBe('1'))
+    return redis.renamenx('foo', 'bar').then(status => expect(status).toBe(1))
       .then(() => {
         expect(redis.data.has('foo')).toBe(false);
         expect(redis.data.get('bar')).toBe('baz');
@@ -23,7 +23,7 @@ describe('renamenx', () => {
         bar: 'foobar',
       },
     });
-    return redis.renamenx('foo', 'bar').then(status => expect(status).toBe('0'))
+    return redis.renamenx('foo', 'bar').then(status => expect(status).toBe(0))
       .then(() => {
         expect(redis.data.get('foo')).toBe('baz');
         expect(redis.data.get('bar')).toBe('foobar');

--- a/test/commands/rpop.js
+++ b/test/commands/rpop.js
@@ -6,13 +6,13 @@ describe('rpop', () => {
   it('should remove and return last element of list', () => {
     const redis = new MockRedis({
       data: {
-        foo: [1, 2, 3],
+        foo: ['1', '2', '3'],
       },
     });
 
     return redis.rpop('foo')
-      .then(result => expect(result).toBe(3))
-      .then(() => expect(redis.data.get('foo')).toEqual([1, 2]));
+      .then(result => expect(result).toBe('3'))
+      .then(() => expect(redis.data.get('foo')).toEqual(['1', '2']));
   });
 
   it('should return null on empty list', () => {

--- a/test/commands/rpush.js
+++ b/test/commands/rpush.js
@@ -6,12 +6,12 @@ describe('rpush', () => {
   it('should add the values to the list in the correct order', () => {
     const redis = new MockRedis({
       data: {
-        foo: [1],
+        foo: ['1'],
       },
     });
 
     return redis.rpush('foo', 9, 8, 7)
-      .then(() => expect(redis.data.get('foo')).toEqual([1, 9, 8, 7]));
+      .then(() => expect(redis.data.get('foo')).toEqual(['1', '9', '8', '7']));
   });
 
   it('should return the new length of the list', () => {
@@ -19,7 +19,7 @@ describe('rpush', () => {
       data: {},
     });
 
-    return redis.rpush('foo', 9, 8, 7).then(length => expect(length).toBe('3'));
+    return redis.rpush('foo', 9, 8, 7).then(length => expect(length).toBe(3));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {

--- a/test/commands/rpushx.js
+++ b/test/commands/rpushx.js
@@ -6,27 +6,27 @@ describe('rpushx', () => {
   it('should add the values to the list in the correct order', () => {
     const redis = new MockRedis({
       data: {
-        foo: [1],
+        foo: ['1'],
       },
     });
 
     return redis.rpushx('foo', 2)
-      .then(() => expect(redis.data.get('foo')).toEqual([1, 2]));
+      .then(() => expect(redis.data.get('foo')).toEqual(['1', '2']));
   });
 
   it('should return the new length of the list', () => {
     const redis = new MockRedis({
       data: {
-        foo: [1],
+        foo: ['1'],
       },
     });
 
-    return redis.rpushx('foo', 2).then(result => expect(result).toBe('2'));
+    return redis.rpushx('foo', 2).then(result => expect(result).toBe(2));
   });
 
   it('should return 0 if list does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.rpushx('foo', 1).then(result => expect(result).toBe('0'));
+    return redis.rpushx('foo', 1).then(result => expect(result).toBe(0));
   });
 });

--- a/test/commands/scard.js
+++ b/test/commands/scard.js
@@ -11,7 +11,7 @@ describe('scard', () => {
       },
     });
 
-    return redis.scard('foo').then(length => expect(length).toBe('3'));
+    return redis.scard('foo').then(length => expect(length).toBe(3));
   });
 
   it('should return 0 if the set does not exist', () => {
@@ -20,7 +20,7 @@ describe('scard', () => {
       },
     });
 
-    return redis.scard('foo').then(length => expect(length).toBe('0'));
+    return redis.scard('foo').then(length => expect(length).toBe(0));
   });
 
   it('should throw an exception if the key contains something other than a set', () => {

--- a/test/commands/set.js
+++ b/test/commands/set.js
@@ -8,4 +8,10 @@ describe('set', () => {
     return redis.set('foo', 'bar').then(status => expect(status).toBe('OK'))
       .then(() => expect(redis.data.get('foo')).toBe('bar'));
   });
+
+  it('should turn number to string', () => {
+    const redis = new MockRedis();
+    return redis.set('foo', 1.5).then(status => expect(status).toBe('OK'))
+      .then(() => expect(redis.data.get('foo')).toBe('1.5'));
+  });
 });

--- a/test/commands/setnx.js
+++ b/test/commands/setnx.js
@@ -6,13 +6,13 @@ describe('setnx', () => {
   it('should set a key with value if it does not exist already', () => {
     const redis = new MockRedis();
     return redis.setnx('foo', 'bar')
-      .then(status => expect(status).toBe('1'))
+      .then(status => expect(status).toBe(1))
       .then(() => {
         expect(redis.data.get('foo'))
           .toBe('bar', 'value failed to persist');
         return redis.setnx('foo', 'baz');
       })
-      .then(status => expect(status).toBe('0', 'setnx no-op failed on existing key'))
+      .then(status => expect(status).toBe(0, 'setnx no-op failed on existing key'))
       .then(() => {
         expect(redis.data.get('foo'))
           .toBe('bar', 'existing value was overwritten');

--- a/test/commands/sismember.js
+++ b/test/commands/sismember.js
@@ -11,8 +11,8 @@ describe('sismember', () => {
       },
     });
 
-    return redis.sismember('foos', 'foo').then(result => expect(result).toBe(true))
+    return redis.sismember('foos', 'foo').then(result => expect(result).toBe(1))
       .then(() => redis.sismember('foos', 'foobar'))
-      .then(result => expect(result).toBe(false));
+      .then(result => expect(result).toBe(0));
   });
 });

--- a/test/commands/srem.js
+++ b/test/commands/srem.js
@@ -10,11 +10,11 @@ describe('srem', () => {
     },
   });
   it('should remove 1 item from set', () =>
-    redis.srem('foos', 'bar').then(status => expect(status).toBe(1))
+    redis.srem('foos', 'bar').then(status => expect(status).toBe('1'))
       .then(() => expect(redis.data.get('foos').has('bar')).toBe(false))
   );
   it('should remove 2 items from set', () =>
-    redis.srem('foos', 'foo', 'baz', 'none existent').then(status => expect(status).toBe(2))
+    redis.srem('foos', 'foo', 'baz', 'none existent').then(status => expect(status).toBe('2'))
       .then(() => {
         expect(redis.data.get('foos').has('bar')).toBe(false);
         expect(redis.data.get('foos').has('baz')).toBe(false);

--- a/test/commands/srem.js
+++ b/test/commands/srem.js
@@ -10,11 +10,11 @@ describe('srem', () => {
     },
   });
   it('should remove 1 item from set', () =>
-    redis.srem('foos', 'bar').then(status => expect(status).toBe('1'))
+    redis.srem('foos', 'bar').then(status => expect(status).toBe(1))
       .then(() => expect(redis.data.get('foos').has('bar')).toBe(false))
   );
   it('should remove 2 items from set', () =>
-    redis.srem('foos', 'foo', 'baz', 'none existent').then(status => expect(status).toBe('2'))
+    redis.srem('foos', 'foo', 'baz', 'none existent').then(status => expect(status).toBe(2))
       .then(() => {
         expect(redis.data.get('foos').has('bar')).toBe(false);
         expect(redis.data.get('foos').has('baz')).toBe(false);

--- a/test/commands/strlen.js
+++ b/test/commands/strlen.js
@@ -6,7 +6,7 @@ describe('strlen', () => {
   it('should return 0 on keys that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.strlen('nonexisting').then(result => expect(result).toBe('0'));
+    return redis.strlen('nonexisting').then(result => expect(result).toBe(0));
   });
 
   it('should return string length of keys that do exist', () => {
@@ -16,6 +16,6 @@ describe('strlen', () => {
       },
     });
 
-    return redis.strlen('mykey').then(result => expect(result).toBe('11'));
+    return redis.strlen('mykey').then(result => expect(result).toBe(11));
   });
 });

--- a/test/commands/ttl.js
+++ b/test/commands/ttl.js
@@ -6,7 +6,7 @@ describe('ttl', () => {
   it('should return -2 if key does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.ttl('foo').then(result => expect(result).toBe('-2'));
+    return redis.ttl('foo').then(result => expect(result).toBe(-2));
   });
 
   it('should return -1 if key exist but have no expire', () => {
@@ -16,7 +16,7 @@ describe('ttl', () => {
       },
     });
 
-    return redis.ttl('foo').then(result => expect(result).toBe('-1'));
+    return redis.ttl('foo').then(result => expect(result).toBe(-1));
   });
 
   it('should return seconds left until expire', () => {
@@ -27,6 +27,6 @@ describe('ttl', () => {
     });
 
     return redis.expire('foo', 1).then(() => redis.ttl('foo'))
-      .then(result => expect(result).toBe('1'));
+      .then(result => expect(result).toBe(1));
   });
 });

--- a/test/exec.js
+++ b/test/exec.js
@@ -14,6 +14,6 @@ describe('exec', () => {
     return redis.multi([
       ['incr', 'user_next'],
       ['incr', 'post_next'],
-    ]).exec().then(results => expect(results).toEqual([[null, '2'], [null, '2']]));
+    ]).exec().then(results => expect(results).toEqual([[null, 2], [null, 2]]));
   });
 });


### PR DESCRIPTION
The return types of commands is very inconsistent and does not follow the spec. For instance APPEND returns a string but should return an integer like ioredis does.

This PR brings the codebase in line with that spec. It also removes non-standard behavior in a few other commands that implement argument transformers in their own way.