### PR TITLE
Add event emitter inheritance in order to use ioredismock as we use ioredis

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,11 +1,14 @@
+import EventEmitter from 'events';
+
 import * as commands from './commands';
 
 import createCommand from './command';
 import createData from './data';
 import createExpires from './expires';
 
-class RedisMock {
+class RedisMock extends EventEmitter {
   constructor({ data = {} } = { }) {
+    super();
     this.channels = {};
     this.batch = [];
 


### PR DESCRIPTION
Hey,

I know this is no a full-implementation of an event based mechanism, but it allows us to use ioredis-mock as we use ioredis.

Meaning:

```javascript
function createClient (options, isPrimary) {
  const client = redis.createClient(options.port, options.hostname)

  client.on('error', function (err) {
    console.error(`An error occurred in ${redisClientName} redis`, err)
    errorHandler(err)
  })

  client.on('connect', function () {
    console.info(`Connection to ${redisClientName} redis established`)
    connectHandler()
  })

  client.on('reconnecting', function () {
    // Reconnection is managed directly by node redis
    console.info(`Reconnecting to ${redisClientName} redis`)
    reconnectingHandler()
  })

  client.on('end', function () {
    console.warn(`Disconnected from ${redisClientName} redis`)
    endHandler()
  })

  return client
}
```