### PR TITLE
Trigger connect & ready events on instantiation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,11 @@ class RedisMock extends EventEmitter {
     Object.keys(commands).forEach((command) => {
       this[command] = createCommand(commands[command].bind(this));
     });
+
+    process.nextTick(() => {
+      this.emit('connect');
+      this.emit('ready');
+    });
   }
   multi(batch) {
     this.batch = batch.map(([command, ...options]) => this[command].bind(this, ...options));

--- a/test/events.js
+++ b/test/events.js
@@ -1,0 +1,19 @@
+import expect, { createSpy } from 'expect';
+
+import MockRedis from '../src';
+
+describe('events', () => {
+  it('should trigger ready and connect events on instantiation', (done) => {
+    const redis = new MockRedis({});
+    const readySpy = createSpy();
+    const connectSpy = createSpy();
+    redis.on('ready', readySpy);
+    redis.on('connect', connectSpy);
+
+    setImmediate(() => {
+      expect(connectSpy).toHaveBeenCalled('connect event not emitted');
+      expect(readySpy).toHaveBeenCalled('ready event not emitted');
+      done();
+    });
+  });
+});


### PR DESCRIPTION
This PR simply makes the redis mock trigger `connect` and `ready` events after instantiation (upon the next tick).

Would be nice to have this merged and published along with the previous commit which introduced the EventEmitter inheritance in the first place, as this is preventing us from using it, currently.

