### PR TITLE
Don't modify objects passed to or returned from the internal datastore

### DIFF
--- a/src/buffer.js
+++ b/src/buffer.js
@@ -1,0 +1,6 @@
+const nodeMajorVersion = +process.versions.node.match(/^\d+/);
+
+export default function createBuffer(data) {
+  return nodeMajorVersion >= 6 ? Buffer.from(data) : new Buffer(data);
+}
+

--- a/src/commands/hdel.js
+++ b/src/commands/hdel.js
@@ -1,9 +1,12 @@
 export function hdel(key, ...fields) {
-  return fields.filter((field) => {
-    if ({}.hasOwnProperty.call(this.data.get(key), field)) {
-      delete this.data.get(key)[field];
+  const value = this.data.get(key);
+  const numDeleted = fields.filter((field) => {
+    if ({}.hasOwnProperty.call(value, field)) {
+      delete value[field];
       return true;
     }
     return false;
   }).length;
+  this.data.set(key, value);
+  return numDeleted;
 }

--- a/src/commands/hincrby.js
+++ b/src/commands/hincrby.js
@@ -2,11 +2,14 @@ export function hincrby(key, field, increment = 0) {
   if (!this.data.has(key)) {
     this.data.set(key, { [field]: '0' });
   }
-  if (!{}.hasOwnProperty.call(this.data.get(key), field)) {
-    this.data.get(key)[field] = '0';
+  const hash = this.data.get(key);
+  if (!{}.hasOwnProperty.call(hash, field)) {
+    hash[field] = '0';
   }
-  const curVal = Number(this.data.get(key)[field]);
+  const curVal = Number(hash[field]);
   const nextVal = curVal + parseInt(increment, 10);
-  this.data.get(key)[field] = nextVal.toString();
+  hash[field] = nextVal.toString();
+  this.data.set(key, hash);
+
   return nextVal;
 }

--- a/src/commands/hincrbyfloat.js
+++ b/src/commands/hincrbyfloat.js
@@ -2,10 +2,12 @@ export function hincrbyfloat(key, field, increment) {
   if (!this.data.has(key)) {
     this.data.set(key, { [field]: '0' });
   }
-  if (!{}.hasOwnProperty.call(this.data.get(key), field)) {
-    this.data.get(key)[field] = '0';
+  const hash = this.data.get(key);
+  if (!{}.hasOwnProperty.call(hash, field)) {
+    hash[field] = '0';
   }
-  const curVal = parseFloat(this.data.get(key)[field]);
-  this.data.get(key)[field] = (curVal + parseFloat(increment)).toString();
-  return this.data.get(key)[field];
+  const curVal = parseFloat(hash[field]);
+  hash[field] = (curVal + parseFloat(increment)).toString();
+  this.data.set(key, hash);
+  return hash[field];
 }

--- a/src/commands/hmset.js
+++ b/src/commands/hmset.js
@@ -3,9 +3,13 @@ export function hmset(key, ...hmsetData) {
     this.data.set(key, {});
   }
 
+  const hash = this.data.get(key);
+
   for (let i = 0; i < hmsetData.length; i += 2) {
-    this.data.get(key)[hmsetData[i]] = hmsetData[i + 1];
+    hash[hmsetData[i]] = hmsetData[i + 1];
   }
+
+  this.data.set(key, hash);
 
   return 'OK';
 }

--- a/src/commands/hset.js
+++ b/src/commands/hset.js
@@ -12,5 +12,7 @@ export function hset(key, hashKey, hashVal) {
 
   hash[hashKey] = hashVal;
 
+  this.data.set(key, hash);
+
   return reply;
 }

--- a/src/commands/hsetnx.js
+++ b/src/commands/hsetnx.js
@@ -4,7 +4,9 @@ export function hsetnx(key, hashKey, hashVal) {
   }
 
   if (!{}.hasOwnProperty.call(this.data.get(key), hashKey)) {
-    this.data.get(key)[hashKey] = hashVal;
+    const hash = this.data.get(key);
+    hash[hashKey] = hashVal;
+    this.data.set(key, hash);
 
     return 1;
   }

--- a/src/commands/lpop.js
+++ b/src/commands/lpop.js
@@ -4,5 +4,9 @@ export function lpop(key) {
   }
   const list = this.data.get(key) || [];
 
-  return list.length > 0 ? list.shift() : null;
+  const item = list.length > 0 ? list.shift() : null;
+
+  this.data.set(key, list);
+
+  return item;
 }

--- a/src/commands/lset.js
+++ b/src/commands/lset.js
@@ -10,5 +10,7 @@ export function lset(key, i, value) {
   const index = parseInt(i, 10);
   const list = this.data.get(key) || [];
   list[index < 0 ? list.length + index : index] = value;
+  this.data.set(key, list);
+
   return 'OK';
 }

--- a/src/commands/rpop.js
+++ b/src/commands/rpop.js
@@ -4,5 +4,9 @@ export function rpop(key) {
   }
   const list = this.data.get(key) || [];
 
-  return list.length > 0 ? list.pop() : null;
+  const item = list.length > 0 ? list.pop() : null;
+
+  this.data.set(key, list);
+
+  return item;
 }

--- a/src/commands/rpoplpush.js
+++ b/src/commands/rpoplpush.js
@@ -14,8 +14,14 @@ export function rpoplpush(source, destination) {
     this.data.set(destination, []);
   }
 
-  const item = this.data.get(source).pop();
-  this.data.get(destination).unshift(item);
+  const newSource = this.data.get(source);
+  const item = newSource.pop();
+
+  const newDest = this.data.get(destination);
+  newDest.unshift(item);
+
+  this.data.set(source, newSource);
+  this.data.set(destination, newDest);
 
   return item;
 }

--- a/src/commands/sadd.js
+++ b/src/commands/sadd.js
@@ -12,5 +12,6 @@ export function sadd(key, ...vals) {
     }
     set.add(value);
   });
+  this.data.set(key, set);
   return added;
 }

--- a/src/commands/smove.js
+++ b/src/commands/smove.js
@@ -18,12 +18,15 @@ export function smove(source, destination, member) {
   }
 
   sourceSet.delete(member);
+  this.data.set(source, sourceSet);
 
   if (!this.data.has(destination)) {
     this.data.set(destination, new Set());
   }
 
-  this.data.get(destination).add(member);
+  const destSet = this.data.get(destination);
+  destSet.add(member);
+  this.data.set(destination, destSet);
 
   return 1;
 }

--- a/src/commands/srem.js
+++ b/src/commands/srem.js
@@ -7,5 +7,6 @@ export function srem(key, ...vals) {
     }
     set.delete(val);
   });
+  this.data.set(key, set);
   return removed;
 }

--- a/src/data.js
+++ b/src/data.js
@@ -16,7 +16,25 @@ export default function createData(expires, initial = {}) {
         this.delete(key);
       }
 
-      return raw[key];
+      const value = raw[key];
+
+      if (Array.isArray(value)) {
+        return value.slice();
+      }
+
+      if (Buffer.isBuffer(value)) {
+        return Buffer.from(value);
+      }
+
+      if (value instanceof Set) {
+        return new Set(value);
+      }
+
+      if (typeof value === 'object' && value) {
+        return Object.assign({}, value);
+      }
+
+      return value;
     },
     has(key) {
       if (expires.has(key) && expires.isExpired(key)) {

--- a/src/data.js
+++ b/src/data.js
@@ -1,3 +1,7 @@
+import { assign } from 'lodash';
+
+import createBuffer from './buffer';
+
 export default function createData(expires, initial = {}) {
   let raw = {};
   const data = Object.freeze({
@@ -23,7 +27,7 @@ export default function createData(expires, initial = {}) {
       }
 
       if (Buffer.isBuffer(value)) {
-        return Buffer.from(value);
+        return createBuffer(value);
       }
 
       if (value instanceof Set) {
@@ -31,7 +35,7 @@ export default function createData(expires, initial = {}) {
       }
 
       if (typeof value === 'object' && value) {
-        return Object.assign({}, value);
+        return assign({}, value);
       }
 
       return value;
@@ -52,11 +56,11 @@ export default function createData(expires, initial = {}) {
       if (Array.isArray(val)) {
         item = val.slice();
       } else if (Buffer.isBuffer(val)) {
-        item = Buffer.from(val);
+        item = createBuffer(val);
       } else if (val instanceof Set) {
         item = new Set(val);
       } else if (typeof val === 'object' && val) {
-        item = Object.assign({}, val);
+        item = assign({}, val);
       }
 
       raw[key] = item;

--- a/src/data.js
+++ b/src/data.js
@@ -47,7 +47,19 @@ export default function createData(expires, initial = {}) {
       return Object.keys(raw);
     },
     set(key, val) {
-      raw[key] = val;
+      let item = val;
+
+      if (Array.isArray(val)) {
+        item = val.slice();
+      } else if (Buffer.isBuffer(val)) {
+        item = Buffer.from(val);
+      } else if (val instanceof Set) {
+        item = new Set(val);
+      } else if (typeof val === 'object' && val) {
+        item = Object.assign({}, val);
+      }
+
+      raw[key] = item;
     },
   });
 

--- a/test/buffer.js
+++ b/test/buffer.js
@@ -1,0 +1,24 @@
+import expect from 'expect';
+
+import createBuffer from '../src/buffer';
+
+describe('createBuffer', () => {
+  it('should create a buffer from an array', () => {
+    const buffer = createBuffer([0x31, 0x32, 0x33]);
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(buffer.toString()).toEqual('123');
+  });
+
+  it('should create a buffer from a buffer', () => {
+    const buffer1 = createBuffer([0x31, 0x32, 0x33]);
+    const buffer2 = createBuffer(buffer1);
+    expect(buffer1.equals(buffer2)).toBe(true);
+  });
+
+  it('should create a buffer from a string', () => {
+    const buffer = createBuffer('123');
+    expect(Buffer.isBuffer(buffer)).toBe(true);
+    expect(buffer.toString()).toEqual('123');
+  });
+});
+

--- a/test/commands/getBuffer.js
+++ b/test/commands/getBuffer.js
@@ -27,6 +27,6 @@ describe('getBuffer', () => {
       },
     });
 
-    return redis.getBuffer('foo').then(result => expect(result).toBe(bufferVal));
+    return redis.getBuffer('foo').then(result => expect(result.equals(bufferVal)).toBe(true));
   });
 });

--- a/test/commands/hgetall.js
+++ b/test/commands/hgetall.js
@@ -14,6 +14,6 @@ describe('hgetall', () => {
       },
     });
 
-    return redis.hgetall('emails').then(result => expect(result).toBe(emails));
+    return redis.hgetall('emails').then(result => expect(result).toEqual(emails));
   });
 });

--- a/test/data.js
+++ b/test/data.js
@@ -1,5 +1,6 @@
 import expect from 'expect';
 
+import createBuffer from '../src/buffer';
 import createData from '../src/data';
 import createExpires from '../src/expires';
 
@@ -19,7 +20,7 @@ describe('get', () => {
     data = createData(createExpires(), {
       myString: 'qwerty',
       mySet: new Set([1, 2, 3]),
-      myBuffer: Buffer.from([0x31, 0x32, 0x33]),
+      myBuffer: createBuffer([0x31, 0x32, 0x33]),
       myArray: [1, 2, 3],
       myObject: { a: 1, b: 2, c: 3 },
     });
@@ -50,7 +51,7 @@ describe('get', () => {
   it('should return buffer copies from the cache', () => {
     const myBuffer = data.get('myBuffer');
     myBuffer[0] = 0x32;
-    expect(data.get('myBuffer')).toEqual(Buffer.from([0x31, 0x32, 0x33]));
+    expect(data.get('myBuffer')).toEqual(createBuffer([0x31, 0x32, 0x33]));
   });
 });
 
@@ -88,9 +89,9 @@ describe('set', () => {
   });
 
   it('should set copies of buffers in the cache', () => {
-    const myBuffer = Buffer.from([0x31, 0x32, 0x33]);
+    const myBuffer = createBuffer([0x31, 0x32, 0x33]);
     data.set('myBuffer', myBuffer);
     myBuffer[0] = 0x32;
-    expect(data.get('myBuffer')).toEqual(Buffer.from([0x31, 0x32, 0x33]));
+    expect(data.get('myBuffer')).toEqual(createBuffer([0x31, 0x32, 0x33]));
   });
 });

--- a/test/data.js
+++ b/test/data.js
@@ -11,3 +11,45 @@ describe('createData', () => {
     expect(data.get('foo')).toNotExist();
   });
 });
+
+describe('get', () => {
+  let data;
+
+  beforeEach(() => {
+    data = createData(createExpires(), {
+      myString: 'qwerty',
+      mySet: new Set([1, 2, 3]),
+      myBuffer: Buffer.from([0x31, 0x32, 0x33]),
+      myArray: [1, 2, 3],
+      myObject: { a: 1, b: 2, c: 3 },
+    });
+  });
+
+  it('should return string values from the cache', () => {
+    expect(data.get('myString')).toEqual('qwerty');
+  });
+
+  it('should return array copies from the cache', () => {
+    const myArray = data.get('myArray');
+    myArray.push(4);
+    expect(data.get('myArray')).toEqual([1, 2, 3]);
+  });
+
+  it('should return object copies in the cache', () => {
+    const myObject = data.get('myObject');
+    myObject.d = 4;
+    expect(data.get('myObject')).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it('should return set copies from the cache', () => {
+    const mySet = data.get('mySet');
+    mySet.add(4);
+    expect(data.get('mySet')).toEqual(new Set([1, 2, 3]));
+  });
+
+  it('should return buffer copies from the cache', () => {
+    const myBuffer = data.get('myBuffer');
+    myBuffer[0] = 0x32;
+    expect(data.get('myBuffer')).toEqual(Buffer.from([0x31, 0x32, 0x33]));
+  });
+});

--- a/test/data.js
+++ b/test/data.js
@@ -53,3 +53,44 @@ describe('get', () => {
     expect(data.get('myBuffer')).toEqual(Buffer.from([0x31, 0x32, 0x33]));
   });
 });
+
+describe('set', () => {
+  let data;
+
+  beforeEach(() => {
+    data = createData(createExpires(), {});
+  });
+
+  it('should set string values in the cache', () => {
+    data.set('myString', 'qwerty');
+    expect(data.get('myString')).toEqual('qwerty');
+  });
+
+  it('should set copies of arrays in the cache', () => {
+    const myArray = [1, 2, 3];
+    data.set('myArray', myArray);
+    myArray.push(4);
+    expect(data.get('myArray')).toEqual([1, 2, 3]);
+  });
+
+  it('should set copies of objects in the cache', () => {
+    const myObject = { a: 1, b: 2, c: 3 };
+    data.set('myObject', myObject);
+    myObject.d = 4;
+    expect(data.get('myObject')).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it('should set copies of sets in the cache', () => {
+    const mySet = new Set([1, 2, 3]);
+    data.set('mySet', mySet);
+    mySet.add(4);
+    expect(data.get('mySet')).toEqual(new Set([1, 2, 3]));
+  });
+
+  it('should set copies of buffers in the cache', () => {
+    const myBuffer = Buffer.from([0x31, 0x32, 0x33]);
+    data.set('myBuffer', myBuffer);
+    myBuffer[0] = 0x32;
+    expect(data.get('myBuffer')).toEqual(Buffer.from([0x31, 0x32, 0x33]));
+  });
+});


### PR DESCRIPTION
I ran into an issue today when testing hash commands with ioredis-mock.

I had code similar to the below snippet where I was fetching a hash from Redis with `hgetall`,
sorting the value stored at one of the hash keys, and updating that value with `hset`.

When updating the Redis cache, the object returned from the call `hgetall` call was directly modified with the new values passed to `hset` because it was directly referencing the object stored in ioredis-mock's internal datastore:

```javascript
redis.multi([
  ['hgetall', myKey],
  // ...
]).exec().then((cacheResult) => {
  cacheResult.data = JSON.parse(cacheResult.data);
  console.log(typeof cacheResult.data); // 'object'

  /* modify cacheResult.data */

  return redis.multi([
    ['hset', myKey, 'data', JSON.stringify(cacheResult.data)],
    // ...
  ]).exec().then(() => {
    console.log(typeof cacheResult.data); // 'string'
    return cacheResult.data;
  });
});
```

This PR updates the `set` and `get` calls in the internal datastore to work with copies of data rather than the original objects.