### PR TITLE
fix hash get commands for missing hashes

### DIFF
--- a/src/commands/hget.js
+++ b/src/commands/hget.js
@@ -1,3 +1,9 @@
 export function hget(key, hashKey) {
-  return this.data.get(key)[hashKey];
+  const hash = this.data.get(key);
+
+  if (!hash || hash[hashKey] === undefined) {
+    return null;
+  }
+
+  return hash[hashKey];
 }

--- a/src/commands/hgetall.js
+++ b/src/commands/hgetall.js
@@ -1,3 +1,3 @@
 export function hgetall(key) {
-  return this.data.get(key);
+  return this.data.get(key) || {};
 }

--- a/src/commands/hmget.js
+++ b/src/commands/hmget.js
@@ -1,3 +1,9 @@
 export function hmget(key, ...fields) {
-  return fields.map(field => this.data.get(key)[field] || null);
+  const hash = this.data.get(key);
+  return fields.map((field) => {
+    if (!hash || hash[field] === undefined) {
+      return null;
+    }
+    return hash[field];
+  });
 }

--- a/test/commands/hget.js
+++ b/test/commands/hget.js
@@ -14,4 +14,21 @@ describe('hget', () => {
 
     return redis.hget('emails', 'clark@daily.planet').then(userId => expect(userId).toBe('1'));
   });
+
+  it('should return null if the hash does not exist', () => {
+    const redis = new MockRedis();
+    return redis.hget('emails', 'clark@daily.planet').then(userId => expect(userId).toBe(null));
+  });
+
+  it('should return null if the item does not exist in the hash', () => {
+    const redis = new MockRedis({
+      data: {
+        emails: {
+          'clark@daily.planet': '1',
+        },
+      },
+    });
+
+    return redis.hget('emails', 'lois@daily.planet').then(userId => expect(userId).toBe(null));
+  });
 });

--- a/test/commands/hgetall.js
+++ b/test/commands/hgetall.js
@@ -16,4 +16,9 @@ describe('hgetall', () => {
 
     return redis.hgetall('emails').then(result => expect(result).toEqual(emails));
   });
+
+  it('should return an empty object if the hash does not exist', () => {
+    const redis = new MockRedis();
+    return redis.hgetall('emails').then(result => expect(result).toEqual({}));
+  });
 });

--- a/test/commands/hmget.js
+++ b/test/commands/hmget.js
@@ -14,4 +14,11 @@ describe('hmget', () => {
         '1', 'bruce@wayne.enterprises', null,
       ]));
   });
+
+  it('should return an array of nulls if the hash does not exist', () => {
+    const redis = new MockRedis();
+    return redis.hmget('user:1', 'id', 'email', 'location').then(values =>
+      expect(values).toEqual([null, null, null])
+    );
+  });
 });


### PR DESCRIPTION
This PR modifies the behavior of the `HGET` / `HMGET` / `HGETALL` commands to mimic that of ioredis:

- `HGET` now returns `null` if the hash doesn't exist or if the key doesn't exist in the hash
- `HMGET` now returns an array of `null`s if the hash doesn't exist
- `HGETALL` now returns an empty object (`{}`) if the hash doesn't exist