### PR TITLE
Only run ESlint checks on TravisCI for Pull Requests

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -8,11 +8,7 @@ engines:
       languages:
       - javascript
   eslint:
-    enabled: true
-    channel: "eslint-2"
-    checks:
-      import/no-unresolved:
-        enabled: false
+    enabled: false
   fixme:
     enabled: true
 ratings:


### PR DESCRIPTION
CodeClimate ESlint checks disabled as their version is consistently
behind ours.