### PR TITLE
Add Subscribe Stub

### DIFF
--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -83,6 +83,7 @@ export * from './spop';
 export * from './srandmember';
 export * from './srem';
 export * from './strlen';
+export * from './subscribe';
 export * from './sunion';
 export * from './time';
 export * from './ttl';

--- a/src/commands/subscribe.js
+++ b/src/commands/subscribe.js
@@ -1,0 +1,3 @@
+export function subscribe(...args) {
+  return args.length;
+}

--- a/test/commands/subscribe.js
+++ b/test/commands/subscribe.js
@@ -1,0 +1,9 @@
+import expect from 'expect';
+
+import MockRedis from '../../src';
+
+describe('subscribe', () => {
+  const redis = new MockRedis();
+  it('should return number of subscribed channels', () =>
+    redis.subscribe('news', 'music').then(subNum => expect(subNum).toBe(2)));
+});


### PR DESCRIPTION
Add `redis.subscribe('channel')` stub command, since there is a `publish` stub command.