### PR TITLE
Use `Set` for `srandmember`.

### DIFF
--- a/src/commands/srandmember.js
+++ b/src/commands/srandmember.js
@@ -1,11 +1,14 @@
-import { random } from 'lodash';
+import { shuffle, random } from 'lodash';
+import Set from 'es6-set';
+import arrayFrom from 'array-from';
 
 export function srandmember(key, count) {
-  if (this.data.has(key) && !(this.data.get(key) instanceof Array)) {
+  if (this.data.has(key) && !(this.data.get(key) instanceof Set)) {
     throw new Error(`Key ${key} does not contain a set`);
   }
 
-  const list = this.data.get(key) || [];
+  const set = this.data.get(key) || new Set();
+  const list = arrayFrom(set);
   const total = list.length;
 
   if (total === 0) {
@@ -16,19 +19,17 @@ export function srandmember(key, count) {
   const max = shouldReturnArray ? Math.abs(count) : 1;
   const skipDuplicates = shouldReturnArray && count > -1;
 
-  if (total <= max && skipDuplicates) {
-    return list;
+  if (skipDuplicates) {
+    return shuffle(list.splice(0, max));
   }
 
   const items = [];
   let results = 0;
   while (results < max) {
     const item = list[random(0, total - 1)];
+    items.push(item);
 
-    if (!skipDuplicates || items.indexOf(item) === -1) {
-      results += 1;
-      items.push(item);
-    }
+    results += 1;
   }
 
   return shouldReturnArray ? items : items[0];

--- a/test/commands/srandmember.js
+++ b/test/commands/srandmember.js
@@ -1,4 +1,5 @@
 import expect from 'expect';
+import Set from 'es6-set';
 
 import MockRedis from '../../src';
 
@@ -6,7 +7,7 @@ describe('srandmember', () => {
   it('should return a random item', () => {
     const redis = new MockRedis({
       data: {
-        myset: ['one', 'two', 'three'],
+        myset: new Set(['one', 'two', 'three']),
       },
     });
 
@@ -18,7 +19,7 @@ describe('srandmember', () => {
   it('should return random unique items', () => {
     const redis = new MockRedis({
       data: {
-        myset: ['one', 'two', 'three'],
+        myset: new Set(['one', 'two', 'three']),
       },
     });
 
@@ -32,19 +33,21 @@ describe('srandmember', () => {
   it('should return set if positive count is bigger than set', () => {
     const redis = new MockRedis({
       data: {
-        myset: ['one', 'two', 'three'],
+        myset: new Set(['one', 'two', 'three']),
       },
     });
 
-    return redis
-      .srandmember('myset', 5)
-      .then(results => expect(results).toEqual(['one', 'two', 'three']));
+    return redis.srandmember('myset', 5).then(results => {
+      expect(['one', 'two', 'three']).toInclude(results[0]);
+      expect(['one', 'two', 'three']).toInclude(results[1]);
+      expect(['one', 'two', 'three']).toInclude(results[2]);
+    });
   });
 
   it('should return random items with specified length', () => {
     const redis = new MockRedis({
       data: {
-        myset: ['one', 'two', 'three'],
+        myset: new Set(['one', 'two', 'three']),
       },
     });
 


### PR DESCRIPTION
Fixes:
- Combining `sadd` and `srandmember`.
- Fix positive count is bigger than the set is not randomized.