### PR TITLE
🐛 #431 Fix spop behaviour 

### DIFF
--- a/src/commands/spop.js
+++ b/src/commands/spop.js
@@ -1,18 +1,21 @@
 import _ from 'lodash';
 import Set from 'es6-set';
 
+const safeCount = count => {
+  const result = count !== undefined ? parseInt(count, 10) : 1;
+  if (Number.isNaN(result) || result < 0) {
+    throw new Error('ERR value is not an integer or out of range');
+  }
+  return result;
+};
+
 export function spop(key, count) {
   if (this.data.has(key) && !(this.data.get(key) instanceof Set)) {
     throw new Error(`Key ${key} does not contain a set`);
   }
-
+  const want = safeCount(count);
   const set = this.data.get(key) || new Set();
   const total = set.size;
-  const want = count !== undefined ? parseInt(count, 10) : 1;
-
-  if (Number.isNaN(count) || count < 0) {
-    throw new Error('ERR value is not an integer or out of range');
-  }
 
   if (want === 0) return undefined;
   if (total === 0) return null;

--- a/src/commands/spop.js
+++ b/src/commands/spop.js
@@ -30,10 +30,8 @@ export function spop(key, count) {
     result = values.sample().value();
     set.delete(result);
   } else {
-    result = values
-      .shuffle()
-      .take(want)
-      .value();
+    values.shuffle(); // Randomize take
+    result = values.take(want).value();
     result.map(item => set.delete(item));
   }
 

--- a/test/commands/spop.js
+++ b/test/commands/spop.js
@@ -12,6 +12,7 @@ describe('spop', () => {
     });
 
     return redis.spop('myset').then(result => {
+      expect(result.constructor).toBe(String);
       expect(['one', 'two', 'three']).toInclude(result);
       expect(redis.data.get('myset').size).toBe(2);
     });
@@ -50,6 +51,18 @@ describe('spop', () => {
     return redis.spop('myset').then(result => expect(result).toBe(null));
   });
 
+  it('should return undefined if count is 0', () => {
+    const redis = new MockRedis({
+      data: {
+        myset: new Set(['one', 'two', 'three']),
+      },
+    });
+
+    return redis
+      .spop('myset', 0)
+      .then(result => expect(result).toBe(undefined));
+  });
+
   it('should throw an exception if the key contains something other than a set', () => {
     const redis = new MockRedis({
       data: {
@@ -60,5 +73,33 @@ describe('spop', () => {
     return redis
       .spop('foo')
       .catch(err => expect(err.message).toBe('Key foo does not contain a set'));
+  });
+
+  it('should throw an exception if count is not an integer', () => {
+    const redis = new MockRedis({
+      data: {
+        myset: new Set(['one', 'two', 'three']),
+      },
+    });
+
+    return redis
+      .spop('myset', 'not an integer')
+      .catch(err =>
+        expect(err.message).toBe('ERR value is not an integer or out of range')
+      );
+  });
+
+  it('should throw an exception if count is out of range', () => {
+    const redis = new MockRedis({
+      data: {
+        myset: new Set(['one', 'two', 'three']),
+      },
+    });
+
+    return redis
+      .spop('myset', -10)
+      .catch(err =>
+        expect(err.message).toBe('ERR value is not an integer or out of range')
+      );
   });
 });


### PR DESCRIPTION
Fix #431. Make `spop` returning single value when count === 1. I took the opportunity to fully use [lodash](https://lodash.com) here.