### PR TITLE
bugfix: zrange functions sort values in lexicographical order

### DIFF
--- a/src/commands/zrange.js
+++ b/src/commands/zrange.js
@@ -17,7 +17,9 @@ export function zrange(key, s, e) {
   const start = parseInt(s, 10);
   const end = parseInt(e, 10);
 
-  const val = orderBy(arrayFrom(map.values()), 'score').map(it => it.value);
+  const val = orderBy(arrayFrom(map.values()), ['score', 'value']).map(
+    it => it.value
+  );
 
   return slice(val, start, end);
 }

--- a/src/commands/zrangebyscore.js
+++ b/src/commands/zrangebyscore.js
@@ -20,7 +20,7 @@ export function zrangebyscore(key, inputMin, inputMax, withScores) {
     filterPredicate(min, max)
   );
 
-  const ordered = orderBy(filteredArray, 'score');
+  const ordered = orderBy(filteredArray, ['score', 'value']);
   if (withScores === 'WITHSCORES') {
     return flatMap(ordered, it => [it.value, it.score]);
   }

--- a/src/commands/zrevrange.js
+++ b/src/commands/zrevrange.js
@@ -17,9 +17,11 @@ export function zrevrange(key, s, e) {
   const start = parseInt(s, 10);
   const end = parseInt(e, 10);
 
-  const val = orderBy(arrayFrom(map.values()), 'score', 'desc').map(
-    it => it.value
-  );
+  const val = orderBy(
+    arrayFrom(map.values()),
+    ['score', 'value'],
+    ['desc', 'desc']
+  ).map(it => it.value);
 
   return slice(val, start, end);
 }

--- a/src/commands/zrevrangebyscore.js
+++ b/src/commands/zrevrangebyscore.js
@@ -20,7 +20,7 @@ export function zrevrangebyscore(key, inputMax, inputMin, withScores) {
     filterPredicate(min, max)
   );
 
-  const ordered = orderBy(filteredArray, 'score', 'desc');
+  const ordered = orderBy(filteredArray, ['score', 'value'], ['desc', 'desc']);
   if (withScores === 'WITHSCORES') {
     return flatMap(ordered, it => [it.value, it.score]);
   }

--- a/test/commands/zrange.js
+++ b/test/commands/zrange.js
@@ -54,4 +54,21 @@ describe('zrange', () => {
 
     return redis.zrange('foo', 0, 2).then(res => expect(res).toEqual([]));
   });
+
+  it('should sort items with the same score lexicographically', () => {
+    const redis = new MockRedis({
+      data: {
+        foo: new Map([
+          ['aaa', { score: 5, value: 'aaa' }],
+          ['ccc', { score: 4, value: 'ccc' }],
+          ['ddd', { score: 4, value: 'ddd' }],
+          ['bbb', { score: 4, value: 'bbb' }],
+        ]),
+      },
+    });
+
+    return redis
+      .zrange('foo', 0, 100)
+      .then(res => expect(res).toEqual(['bbb', 'ccc', 'ddd', 'aaa']));
+  });
 });

--- a/test/commands/zrangebyscore.js
+++ b/test/commands/zrangebyscore.js
@@ -73,4 +73,23 @@ describe('zrangebyscore', () => {
       .zrangebyscore('foo', 1, 3, 'WITHSCORES')
       .then(res => expect(res).toEqual(['first', 1, 'second', 2, 'third', 3]));
   });
+
+  it('should sort items with the same score lexicographically', () => {
+    const redis = new MockRedis({
+      data: {
+        foo: new Map([
+          ['aaa', { score: 5, value: 'aaa' }],
+          ['ccc', { score: 4, value: 'ccc' }],
+          ['ddd', { score: 4, value: 'ddd' }],
+          ['bbb', { score: 4, value: 'bbb' }],
+        ]),
+      },
+    });
+
+    return redis
+      .zrangebyscore('foo', '-inf', '+inf', 'WITHSCORES')
+      .then(res =>
+        expect(res).toEqual(['bbb', 4, 'ccc', 4, 'ddd', 4, 'aaa', 5])
+      );
+  });
 });

--- a/test/commands/zrevrange.js
+++ b/test/commands/zrevrange.js
@@ -54,4 +54,21 @@ describe('zrevrange', () => {
 
     return redis.zrevrange('foo', 0, 2).then(res => expect(res).toEqual([]));
   });
+
+  it('should sort items with the same score in reverse lexicographical order', () => {
+    const redis = new MockRedis({
+      data: {
+        foo: new Map([
+          ['aaa', { score: 5, value: 'aaa' }],
+          ['ccc', { score: 4, value: 'ccc' }],
+          ['ddd', { score: 4, value: 'ddd' }],
+          ['bbb', { score: 4, value: 'bbb' }],
+        ]),
+      },
+    });
+
+    return redis
+      .zrevrange('foo', 0, 100)
+      .then(res => expect(res).toEqual(['aaa', 'ddd', 'ccc', 'bbb']));
+  });
 });

--- a/test/commands/zrevrangebyscore.js
+++ b/test/commands/zrevrangebyscore.js
@@ -73,4 +73,23 @@ describe('zrevrangebyscore', () => {
       .zrevrangebyscore('foo', 3, 1, 'WITHSCORES')
       .then(res => expect(res).toEqual(['third', 3, 'second', 2, 'first', 1]));
   });
+
+  it('should sort items with the same score in reverse lexicographical order', () => {
+    const redis = new MockRedis({
+      data: {
+        foo: new Map([
+          ['aaa', { score: 5, value: 'aaa' }],
+          ['ccc', { score: 4, value: 'ccc' }],
+          ['ddd', { score: 4, value: 'ddd' }],
+          ['bbb', { score: 4, value: 'bbb' }],
+        ]),
+      },
+    });
+
+    return redis
+      .zrevrangebyscore('foo', '+inf', '-inf', 'WITHSCORES')
+      .then(res =>
+        expect(res).toEqual(['aaa', 5, 'ddd', 4, 'ccc', 4, 'bbb', 4])
+      );
+  });
 });


### PR DESCRIPTION
https://redis.io/commands/zrange and https://redis.io/commands/zrangebyscore sort items of equal score in lexicographical order by their values.

https://redis.io/commands/zrevrange and https://redis.io/commands/zrevrangebyscore do the same but in reverse lex order.