### PR TITLE
fix: Don't write undefined with zrem*

### DIFF
--- a/src/commands/zremrangebyrank.js
+++ b/src/commands/zremrangebyrank.js
@@ -2,6 +2,11 @@ import { zrange } from './index';
 
 export function zremrangebyrank(key, s, e) {
   const vals = zrange.call(this, key, s, e);
+
+  if (!this.data.has(key)) {
+    return 0; // Short circuit.
+  }
+
   const map = this.data.get(key);
   vals.forEach(val => {
     map.delete(val);

--- a/src/commands/zremrangebyscore.js
+++ b/src/commands/zremrangebyscore.js
@@ -3,6 +3,10 @@ import { zrevrangebyscore } from './index';
 export function zremrangebyscore(key, inputMax, inputMin) {
   const vals = zrevrangebyscore.call(this, key, inputMax, inputMin);
 
+  if (!this.data.has(key)) {
+    return 0; // Short circuit.
+  }
+
   const map = this.data.get(key);
   vals.forEach(val => {
     map.delete(val);

--- a/test/commands/zremrangebyrank.js
+++ b/test/commands/zremrangebyrank.js
@@ -13,6 +13,16 @@ describe('zremrangebyrank', () => {
       ['fifth', { score: 5, value: 'fifth' }],
     ]),
   };
+
+  it('should do nothing if key does not exist', () => {
+    const redis = new MockRedis({ data: {} });
+
+    return redis
+      .zremrangebyrank('foo', 0, 2)
+      .then(status => expect(status).toBe(0))
+      .then(() => expect(redis.data.has('foo')).toBe(false));
+  });
+
   it('should remove first 3 items ordered by score', () => {
     const redis = new MockRedis({ data });
 

--- a/test/commands/zremrangebyscore.js
+++ b/test/commands/zremrangebyscore.js
@@ -14,6 +14,15 @@ describe('zremrangebyscore', () => {
     ]),
   };
 
+  it('should do nothing if key does not exist', () => {
+    const redis = new MockRedis({ data: {} });
+
+    return redis
+      .zremrangebyscore('foo', 0, 2)
+      .then(status => expect(status).toBe(0))
+      .then(() => expect(redis.data.has('foo')).toBe(false));
+  });
+
   it('should remove using not strict compare', () => {
     const redis = new MockRedis({ data });
 


### PR DESCRIPTION
Follow-up to #539 that mimics actual Redis behavior and avoids writing `undefined` back, which can lead to issues with `zadd`.