### PR TITLE
fix: Support WITHSCORES in zrange

### DIFF
--- a/src/commands/zrange.js
+++ b/src/commands/zrange.js
@@ -1,9 +1,9 @@
 import Map from 'es6-map';
 import arrayFrom from 'array-from';
-import { orderBy } from 'lodash';
+import { flatMap, orderBy } from 'lodash';
 import { slice } from './zrange-command.common';
 
-export function zrange(key, s, e) {
+export function zrange(key, s, e, withScores) {
   const map = this.data.get(key);
   if (!map) {
     return [];
@@ -17,9 +17,18 @@ export function zrange(key, s, e) {
   const start = parseInt(s, 10);
   const end = parseInt(e, 10);
 
-  const val = orderBy(arrayFrom(map.values()), ['score', 'value']).map(
-    it => it.value
+  const ordered = slice(
+    orderBy(arrayFrom(map.values()), ['score', 'value']),
+    start,
+    end
   );
 
-  return slice(val, start, end);
+  if (
+    typeof withScores === 'string' &&
+    withScores.toUpperCase() === 'WITHSCORES'
+  ) {
+    return flatMap(ordered, it => [it.value, it.score]);
+  }
+
+  return ordered.map(it => it.value);
 }

--- a/src/commands/zrangebyscore.js
+++ b/src/commands/zrangebyscore.js
@@ -21,7 +21,10 @@ export function zrangebyscore(key, inputMin, inputMax, withScores) {
   );
 
   const ordered = orderBy(filteredArray, ['score', 'value']);
-  if (withScores === 'WITHSCORES') {
+  if (
+    typeof withScores === 'string' &&
+    withScores.toUpperCase() === 'WITHSCORES'
+  ) {
     return flatMap(ordered, it => [it.value, it.score]);
   }
   return ordered.map(it => it.value);

--- a/src/commands/zrevrangebyscore.js
+++ b/src/commands/zrevrangebyscore.js
@@ -21,7 +21,10 @@ export function zrevrangebyscore(key, inputMax, inputMin, withScores) {
   );
 
   const ordered = orderBy(filteredArray, ['score', 'value'], ['desc', 'desc']);
-  if (withScores === 'WITHSCORES') {
+  if (
+    typeof withScores === 'string' &&
+    withScores.toUpperCase() === 'WITHSCORES'
+  ) {
     return flatMap(ordered, it => [it.value, it.score]);
   }
   return ordered.map(it => it.value);

--- a/test/commands/zrange.js
+++ b/test/commands/zrange.js
@@ -13,6 +13,7 @@ describe('zrange', () => {
       ['fifth', { score: 5, value: 'fifth' }],
     ]),
   };
+
   it('should return first 3 items ordered by score', () => {
     const redis = new MockRedis({ data });
 
@@ -53,6 +54,13 @@ describe('zrange', () => {
     });
 
     return redis.zrange('foo', 0, 2).then(res => expect(res).toEqual([]));
+  });
+
+  it('should include scores if WITHSCORES is specified', () => {
+    const redis = new MockRedis({ data });
+    return redis
+      .zrange('foo', 0, 2, 'WITHSCORES')
+      .then(res => expect(res).toEqual(['first', 1, 'second', 2, 'third', 3]));
   });
 
   it('should sort items with the same score lexicographically', () => {


### PR DESCRIPTION
Also enable case-insensitive use of WITHSCORES.