### PR TITLE
feat: add zscore command

### DIFF
--- a/compat.md
+++ b/compat.md
@@ -178,5 +178,5 @@
 | [zrevrangebyscore](http://redis.io/commands/ZREVRANGEBYSCORE)         | :white_check_mark: | :white_check_mark: |
 | [zrevrank](http://redis.io/commands/ZREVRANK)                         | :white_check_mark: |        :x:         |
 | [zscan](http://redis.io/commands/ZSCAN)                               | :white_check_mark: | :white_check_mark: |
-| [zscore](http://redis.io/commands/ZSCORE)                             | :white_check_mark: |        :x:         |
+| [zscore](http://redis.io/commands/ZSCORE)                             | :white_check_mark: | :white_check_mark: |
 | [zunionstore](http://redis.io/commands/ZUNIONSTORE)                   | :white_check_mark: |        :x:         |

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -108,3 +108,4 @@ export * from './zremrangebyscore';
 export * from './zrevrange';
 export * from './zrevrangebyscore';
 export * from './zscan';
+export * from './zscore';

--- a/src/commands/zscore.js
+++ b/src/commands/zscore.js
@@ -1,0 +1,18 @@
+import Map from 'es6-map';
+
+export function zscore(key, member) {
+  const map = this.data.get(key);
+
+  // @TODO investigate a more stable way to detect sorted lists
+  if (!map || !(map instanceof Map)) {
+    return null;
+  }
+
+  const entry = map.get(member);
+
+  if (!entry) {
+    return null;
+  }
+
+  return entry.score.toString();
+}

--- a/test/commands/zscore.js
+++ b/test/commands/zscore.js
@@ -1,0 +1,41 @@
+import Map from 'es6-map';
+import expect from 'expect';
+
+import MockRedis from '../../src';
+
+describe('zscore', () => {
+  const data = {
+    foo: new Map([
+      ['first', { score: 1, value: 'first' }],
+      ['second', { score: 2, value: 'second' }],
+      ['third', { score: 3, value: 'third' }],
+      ['fourth', { score: 4, value: 'fourth' }],
+      ['fifth', { score: 5, value: 'fifth' }],
+    ]),
+    bar: 'not a sorted set',
+  };
+
+  it('should return the score of an existing member as a string', () => {
+    const redis = new MockRedis({ data });
+
+    return redis.zscore('foo', 'third').then(res => expect(res).toBe('3'));
+  });
+
+  it('should return null when the member does not exist', () => {
+    const redis = new MockRedis({ data });
+
+    return redis.zscore('foo', 'sixth').then(res => expect(res).toNotExist());
+  });
+
+  it('should return null when the key is not a sorted set', () => {
+    const redis = new MockRedis({ data });
+
+    return redis.zscore('bar', 'first').then(res => expect(res).toNotExist());
+  });
+
+  it('should return null when the key does not exist', () => {
+    const redis = new MockRedis({ data });
+
+    return redis.zscore('baz', 'first').then(res => expect(res).toNotExist());
+  });
+});


### PR DESCRIPTION
https://redis.io/commands/ZSCORE

> Returns the score of member in the sorted set at key.
> 
> If member does not exist in the sorted set, or key does not exist, nil is returned.
> 
> Return value
> Bulk string reply: the score of member (a double precision floating point number), represented as  string.