### PR TITLE
fix: Buffer Command Aliases

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "bugs": {
     "url": "https://github.com/stipsan/ioredis-mock/issues"
   },
+  "version": "4.1.1",
   "main": "./lib",
   "files": [
     "example.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   "bugs": {
     "url": "https://github.com/stipsan/ioredis-mock/issues"
   },
-  "version": "4.1.1",
   "main": "./lib",
   "files": [
     "example.js",

--- a/src/commands/brpoplpushBuffer.js
+++ b/src/commands/brpoplpushBuffer.js
@@ -1,3 +1,5 @@
+import { brpoplpush } from './brpoplpush';
+
 export function brpoplpushBuffer(source, destination) {
-  return this.brpoplpush(source, destination);
+  return brpoplpush.apply(this, [source, destination]);
 }

--- a/src/commands/getBuffer.js
+++ b/src/commands/getBuffer.js
@@ -1,3 +1,5 @@
+import { get } from './get';
+
 export function getBuffer(key) {
-  return this.get(key);
+  return get.apply(this, [key]);
 }

--- a/src/commands/lpopBuffer.js
+++ b/src/commands/lpopBuffer.js
@@ -1,3 +1,5 @@
+import { lpop } from './lpop';
+
 export function lpopBuffer(key) {
-  return this.lpop(key);
+  return lpop.apply(this, [key]);
 }

--- a/src/commands/rpopBuffer.js
+++ b/src/commands/rpopBuffer.js
@@ -1,3 +1,5 @@
+import { rpop } from './rpop';
+
 export function rpopBuffer(key) {
-  return this.rpop(key);
+  return rpop.apply(this, [key]);
 }

--- a/src/commands/rpoplpushBuffer.js
+++ b/src/commands/rpoplpushBuffer.js
@@ -1,3 +1,5 @@
+import { rpoplpush } from './rpoplpush';
+
 export function rpoplpushBuffer(source, destination) {
-  return this.rpoplpush(source, destination);
+  return rpoplpush.apply(this, [source, destination]);
 }


### PR DESCRIPTION

Fixes #587 

The “buffer” aliases were causing the commands to get processed twice,
which resulted in the result being wrapped in an extra promise.