### PR TITLE
feat: Support keyprefix option

### DIFF
--- a/src/data.js
+++ b/src/data.js
@@ -4,8 +4,10 @@ import { assign } from 'lodash';
 
 import createBuffer from './buffer';
 
-export default function createData(expires, initial = {}) {
+export default function createData(expires, initial = {}, keyPrefix = '') {
+  const prefix = keyPrefix;
   let raw = {};
+
   const data = Object.freeze({
     clear() {
       raw = {};
@@ -14,15 +16,14 @@ export default function createData(expires, initial = {}) {
       if (expires.has(key)) {
         expires.delete(key);
       }
-
-      delete raw[key];
+      delete raw[`${prefix}${key}`];
     },
     get(key) {
       if (expires.has(key) && expires.isExpired(key)) {
         this.delete(key);
       }
 
-      const value = raw[key];
+      const value = raw[`${prefix}${key}`];
 
       if (Array.isArray(value)) {
         return value.slice();
@@ -51,7 +52,7 @@ export default function createData(expires, initial = {}) {
         this.delete(key);
       }
 
-      return {}.hasOwnProperty.call(raw, key);
+      return {}.hasOwnProperty.call(raw, `${prefix}${key}`);
     },
     keys() {
       return Object.keys(raw);
@@ -71,7 +72,7 @@ export default function createData(expires, initial = {}) {
         item = assign({}, val);
       }
 
-      raw[key] = item;
+      raw[`${prefix}${key}`] = item;
     },
   });
 

--- a/src/expires.js
+++ b/src/expires.js
@@ -1,21 +1,22 @@
-export default function createExpires() {
+export default function createExpires(keyPrefix = '') {
   const expires = {};
+  const prefix = keyPrefix;
 
   return {
     get(key) {
-      return expires[key];
+      return expires[`${prefix}${key}`];
     },
     set(key, timestamp) {
-      expires[key] = +timestamp;
+      expires[`${prefix}${key}`] = +timestamp;
     },
     has(key) {
-      return {}.hasOwnProperty.call(expires, key);
+      return {}.hasOwnProperty.call(expires, `${prefix}${key}`);
     },
     isExpired(key) {
-      return expires[key] <= Date.now();
+      return expires[`${prefix}${key}`] <= Date.now();
     },
     delete(key) {
-      delete expires[key];
+      delete expires[`${prefix}${key}`];
     },
   };
 }

--- a/src/index.js
+++ b/src/index.js
@@ -9,14 +9,14 @@ import Pipeline from './pipeline';
 import promiseContainer from './promise-container';
 
 class RedisMock extends EventEmitter {
-  constructor({ data = {} } = {}) {
+  constructor(options = { data: {}, keyPrefix: '' }) {
     super();
     this.channels = {};
     this.batch = undefined;
 
-    this.expires = createExpires();
+    this.expires = createExpires(options.keyPrefix);
 
-    this.data = createData(this.expires, data);
+    this.data = createData(this.expires, options.data, options.keyPrefix);
 
     Object.keys(commands).forEach(command => {
       this[command] = createCommand(

--- a/test/data.js
+++ b/test/data.js
@@ -14,6 +14,20 @@ describe('createData', () => {
   });
 });
 
+describe('createData with keyprefix', () => {
+  const expires = createExpires('test:');
+  const data = createData(expires, { foo: 'bar' }, 'test:');
+
+  it('should return array  keys of data that with keyprefix', () => {
+    expect(data.keys()).toEqual(['test:foo']);
+  });
+
+  it('should check expiry on get with', () => {
+    expires.set('foo', Date.now());
+    expect(data.get('foo')).toNotExist();
+  });
+});
+
 describe('get', () => {
   let data;
 

--- a/test/keyprefix.js
+++ b/test/keyprefix.js
@@ -1,0 +1,161 @@
+import expect from 'expect';
+import Set from 'es6-set';
+import { WritableMock } from 'stream-mock';
+import Chance from 'chance';
+import MockRedis from '../src';
+
+describe('keyprefix', () => {
+  let writable;
+
+  beforeEach(() => {
+    writable = new WritableMock({ objectMode: true });
+  });
+
+  describe('get', () => {
+    it('should return null on keys that do not exist', () => {
+      const redis = new MockRedis({ keyPrefix: 'test:' });
+      return redis.get('foo').then(result => expect(result).toBe(null));
+    });
+
+    it('should return null on keys that do not exist', () => {
+      const redis = new MockRedis({ keyPrefix: 'test:' });
+      return redis.get('foo').then(result => expect(result).toBe(null));
+    });
+
+    it('should return value of key', () => {
+      const redis = new MockRedis({
+        data: {
+          foo: 'bar',
+        },
+        keyPrefix: 'test:',
+      });
+
+      return redis.get('foo').then(result => expect(result).toBe('bar'));
+    });
+  });
+
+  describe('set', () => {
+    it('should return OK when setting a hash key', () => {
+      const redis = new MockRedis({ keyPrefix: 'test:' });
+      return redis
+        .set('foo', 'bar')
+        .then(status => expect(status).toBe('OK'))
+        .then(() => expect(redis.data.get('foo')).toBe('bar'));
+    });
+
+    it('should turn number to string', () => {
+      const redis = new MockRedis({ keyPrefix: 'test:' });
+      return redis
+        .set('foo', 1.5)
+        .then(status => expect(status).toBe('OK'))
+        .then(() => expect(redis.data.get('foo')).toBe('1.5'));
+    });
+  });
+
+  describe('del', () => {
+    const redis = new MockRedis({
+      data: {
+        deleteme: 'please',
+        metoo: 'pretty please',
+      },
+      keyPrefix: 'test:',
+    });
+
+    it('should delete passed in keys', () =>
+      redis
+        .del('deleteme', 'metoo')
+        .then(status => expect(status).toBe(2))
+        .then(() => expect(redis.data.has('deleteme')).toBe(false))
+        .then(() => expect(redis.data.has('metoo')).toBe(false)));
+
+    it('return the number of keys removed', () =>
+      redis.del('deleteme', 'metoo').then(status => expect(status).toBe(0)));
+  });
+
+  describe('scanSream', () => {
+    it('should batch by count', done => {
+      // Given
+      const chance = new Chance();
+      const keys = chance.unique(chance.word, 100);
+      const count = 11;
+      const redis = new MockRedis({
+        data: { set: new Set(keys) },
+        keyPrefix: 'test:',
+      });
+      const stream = redis.sscanStream('set', { count });
+      // When
+      stream.pipe(writable);
+      writable.on('finish', () => {
+        // Then
+        expect(writable.data.length).toEqual(Math.ceil(keys.length / count));
+        expect(writable.flatData).toEqual(keys);
+        done();
+      });
+    });
+
+    it('should return  keys', done => {
+      // Given
+      const redis = new MockRedis({
+        data: {
+          foo: new Set(['foo0', 'foo1', 'foo2']),
+          zu: new Set(['ZU0', 'ZU1']),
+        },
+        keyPrefix: 'test:',
+      });
+
+      const stream = redis.scanStream();
+      // When
+      stream.pipe(writable);
+      writable.on('finish', () => {
+        // Then
+        expect(writable.flatData).toEqual(['test:foo', 'test:zu']);
+        done();
+      });
+    });
+
+    it('should return only mathced keys', done => {
+      // Given
+      const redis = new MockRedis({
+        data: {
+          set: new Set(['foo0', 'ZU0', 'foo1', 'foo2', 'ZU1']),
+        },
+        keyPrefix: 'test:',
+      });
+
+      const stream = redis.sscanStream('set', { match: 'foo*' });
+      // When
+      stream.pipe(writable);
+      writable.on('finish', () => {
+        // Then
+        expect(writable.flatData).toEqual(['foo0', 'foo1', 'foo2']);
+        done();
+      });
+    });
+  });
+
+  describe('multiple intance use same key with diffence keyPrefix', () => {
+    const redis1 = new MockRedis({
+      data: {
+        foo: 'bar',
+        hello: 'world',
+      },
+      keyPrefix: 'test:',
+    });
+
+    const redis2 = new MockRedis({
+      keyPrefix: 'test2:',
+    });
+
+    it('should return value of key', () =>
+      redis1.get('foo').then(result => expect(result).toEqual('bar')));
+
+    it('should return null on keys that do not exist', () =>
+      redis2.get('foo').then(result => expect(result).toBe(null)));
+
+    it('should return value of key', () =>
+      redis2
+        .set('hello', 'ioredis')
+        .then(status => expect(status).toBe('OK'))
+        .then(() => expect(redis2.data.get('hello')).toBe('ioredis')));
+  });
+});


### PR DESCRIPTION
Fixes #612

This PR is  support keyPrefix option  add keyPrefix test

```js
const cache = new MockRedis({keyPrefix: 'cache:'});
const car = new new MockRedis({keyPrefix: 'car:'});

async test() {
  await cache.set('title', 'ioredis');
  await car.set('title', 'nice car');

  const cacheTitle = await cache.get('title');
  const carTitle = await car.get('title');

  console.log(cacheTitle === carTitle) // fasle
}

```

```js
it('should return  keys', done => {
      // Given
      const redis = new MockRedis({
        data: {
          foo: new Set(['foo0', 'foo1', 'foo2']),
          zu: new Set(['ZU0', 'ZU1']),
        },
        keyPrefix: 'test:',
      });

      const stream = redis.scanStream();
      // When
      stream.pipe(writable);
      writable.on('finish', () => {
        // Then
        expect(writable.flatData).toEqual(['test:foo', 'test:zu']);
        done();
      });
    });
```