### PR TITLE
fix: hdel shouldn't throw an error if key does not exist

### DIFF
--- a/src/commands/hdel.js
+++ b/src/commands/hdel.js
@@ -1,5 +1,8 @@
 export function hdel(key, ...fields) {
   const value = this.data.get(key);
+  if (!value) {
+    return 0;
+  }
   const numDeleted = fields.filter(field => {
     if ({}.hasOwnProperty.call(value, field)) {
       delete value[field];

--- a/test/commands/hdel.js
+++ b/test/commands/hdel.js
@@ -19,4 +19,12 @@ describe('hdel', () => {
       .then(() =>
         expect(redis.data.get('user:1')).toEqual({ name: 'Bruce Wayne' })
       ));
+
+  it('should return 0 for key that does not exist', done => {
+    redis
+      .hdel('nonExistingUser', 'someField')
+      .then(status => expect(status).toBe(0))
+      .then(() => done())
+      .catch(err => done(err));
+  });
 });


### PR DESCRIPTION
if key does not exist return 0
as document states (https://redis.io/commands/hdel)
else an exception is thrown of "TypeError: Cannot convert undefined or null to object"