### PR TITLE
feat: add keyspace notification feature and add 'g' (generic) notifications

### DIFF
--- a/src/commands/del.js
+++ b/src/commands/del.js
@@ -1,19 +1,11 @@
-import {
-  emitKeyspaceNotification,
-  emitKeyeventNotification,
-} from '../keyspace-notifications';
+import { emitNotification } from '../keyspace-notifications';
 
 export function del(...keys) {
   let deleted = 0;
   keys.forEach(key => {
     if (this.data.has(key)) {
       deleted++;
-      if (this.keyspaceEvents.K.g) {
-        emitKeyspaceNotification(this, key, 'del');
-      }
-      if (this.keyspaceEvents.E.g) {
-        emitKeyeventNotification(this, key, 'del');
-      }
+      emitNotification(this, 'g', key, 'del');
     }
     this.data.delete(key);
   });

--- a/src/commands/del.js
+++ b/src/commands/del.js
@@ -1,8 +1,19 @@
+import {
+  emitKeyspaceNotification,
+  emitKeyeventNotification,
+} from '../keyspace-notifications';
+
 export function del(...keys) {
   let deleted = 0;
   keys.forEach(key => {
     if (this.data.has(key)) {
       deleted++;
+      if (this.keyspaceEvents.K.g) {
+        emitKeyspaceNotification(this, key, 'del');
+      }
+      if (this.keyspaceEvents.E.g) {
+        emitKeyeventNotification(this, key, 'del');
+      }
     }
     this.data.delete(key);
   });

--- a/src/commands/expire.js
+++ b/src/commands/expire.js
@@ -1,7 +1,4 @@
-import {
-  emitKeyspaceNotification,
-  emitKeyeventNotification,
-} from '../keyspace-notifications';
+import { emitNotification } from '../keyspace-notifications';
 
 export function expire(key, seconds) {
   if (!this.data.has(key)) {
@@ -9,12 +6,7 @@ export function expire(key, seconds) {
   }
 
   this.expires.set(key, seconds * 1000 + Date.now());
-  if (this.keyspaceEvents.K.g) {
-    emitKeyspaceNotification(this, key, 'expire');
-  }
-  if (this.keyspaceEvents.E.g) {
-    emitKeyeventNotification(this, key, 'expire');
-  }
+  emitNotification(this, 'g', key, 'expire');
 
   return 1;
 }

--- a/src/commands/expire.js
+++ b/src/commands/expire.js
@@ -1,9 +1,20 @@
+import {
+  emitKeyspaceNotification,
+  emitKeyeventNotification,
+} from '../keyspace-notifications';
+
 export function expire(key, seconds) {
   if (!this.data.has(key)) {
     return 0;
   }
 
   this.expires.set(key, seconds * 1000 + Date.now());
+  if (this.keyspaceEvents.K.g) {
+    emitKeyspaceNotification(this, key, 'expire');
+  }
+  if (this.keyspaceEvents.E.g) {
+    emitKeyeventNotification(this, key, 'expire');
+  }
 
   return 1;
 }

--- a/src/commands/rename.js
+++ b/src/commands/rename.js
@@ -1,7 +1,4 @@
-import {
-  emitKeyspaceNotification,
-  emitKeyeventNotification,
-} from '../keyspace-notifications';
+import { emitNotification } from '../keyspace-notifications';
 
 export function rename(key, newKey) {
   const value = this.data.get(key);
@@ -10,21 +7,11 @@ export function rename(key, newKey) {
     const expire = this.expires.get(key);
     this.expires.delete(key);
     this.expires.set(newKey, expire);
-    if (this.keyspaceEvents.K.g) {
-      emitKeyspaceNotification(this, key, 'rename_from');
-    }
-    if (this.keyspaceEvents.E.g) {
-      emitKeyeventNotification(this, key, 'rename_from');
-    }
+    emitNotification(this, 'g', key, 'rename_from');
   }
 
   this.data.set(newKey, value);
   this.data.delete(key);
-  if (this.keyspaceEvents.K.g) {
-    emitKeyspaceNotification(this, newKey, 'rename_to');
-  }
-  if (this.keyspaceEvents.E.g) {
-    emitKeyeventNotification(this, newKey, 'rename_to');
-  }
+  emitNotification(this, 'g', newKey, 'rename_to');
   return 'OK';
 }

--- a/src/commands/rename.js
+++ b/src/commands/rename.js
@@ -7,11 +7,11 @@ export function rename(key, newKey) {
     const expire = this.expires.get(key);
     this.expires.delete(key);
     this.expires.set(newKey, expire);
-    emitNotification(this, 'g', key, 'rename_from');
   }
 
   this.data.set(newKey, value);
   this.data.delete(key);
+  emitNotification(this, 'g', key, 'rename_from');
   emitNotification(this, 'g', newKey, 'rename_to');
   return 'OK';
 }

--- a/src/commands/rename.js
+++ b/src/commands/rename.js
@@ -1,3 +1,8 @@
+import {
+  emitKeyspaceNotification,
+  emitKeyeventNotification,
+} from '../keyspace-notifications';
+
 export function rename(key, newKey) {
   const value = this.data.get(key);
 
@@ -5,9 +10,21 @@ export function rename(key, newKey) {
     const expire = this.expires.get(key);
     this.expires.delete(key);
     this.expires.set(newKey, expire);
+    if (this.keyspaceEvents.K.g) {
+      emitKeyspaceNotification(this, key, 'rename_from');
+    }
+    if (this.keyspaceEvents.E.g) {
+      emitKeyeventNotification(this, key, 'rename_from');
+    }
   }
 
   this.data.set(newKey, value);
   this.data.delete(key);
+  if (this.keyspaceEvents.K.g) {
+    emitKeyspaceNotification(this, newKey, 'rename_to');
+  }
+  if (this.keyspaceEvents.E.g) {
+    emitKeyeventNotification(this, newKey, 'rename_to');
+  }
   return 'OK';
 }

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,14 @@ import createExpires from './expires';
 import emitConnectEvent from './commands-utils/emitConnectEvent';
 import Pipeline from './pipeline';
 import promiseContainer from './promise-container';
+import parseKeyspaceEvents from './keyspace-notifications';
 
-const defaultOptions = { data: {}, keyPrefix: '', lazyConnect: false };
+const defaultOptions = {
+  data: {},
+  keyPrefix: '',
+  lazyConnect: false,
+  notifyKeyspaceEvents: '', // string pattern as specified in https://redis.io/topics/notifications#configuration e.g. 'gxK'
+};
 
 class RedisMock extends EventEmitter {
   constructor(options = {}) {
@@ -30,6 +36,10 @@ class RedisMock extends EventEmitter {
     );
 
     this._initCommands();
+
+    this.keyspaceEvents = parseKeyspaceEvents(
+      optionsWithDefault.notifyKeyspaceEvents
+    );
 
     if (optionsWithDefault.lazyConnect === false) {
       this.connected = true;

--- a/src/keyspace-notifications.js
+++ b/src/keyspace-notifications.js
@@ -40,24 +40,18 @@ export default function parseKeyspaceEvents(keyspaceEventsConfigString) {
   return keyspaceConfig;
 }
 
-export function emitNotification(
-  redisMock,
-  notifType,
-  key,
-  event,
-  database = 0
-) {
-  let channel = null;
-  let message = null;
+function createChannelString(type, name) {
+  const database = 0; // if we support multiple databases in the future, we might want to set this to non-zero
+  const typeString = type === 'K' ? 'keyspace' : 'keyevent';
+  const channel = `__${typeString}@${database}__:${name}`;
+  return channel;
+}
+
+export function emitNotification(redisMock, notifType, key, event) {
   if (redisMock.keyspaceEvents.K[notifType] === true) {
-    channel = `__keyspace@${database}__:${key}`;
-    message = event;
+    redisMock.publish(createChannelString('K', key), event);
   }
   if (redisMock.keyspaceEvents.E[notifType] === true) {
-    channel = `__keyevent@${database}__:${event}`;
-    message = key;
-  }
-  if (channel !== null && message !== null) {
-    redisMock.publish(channel, message);
+    redisMock.publish(createChannelString('E', event), key);
   }
 }

--- a/src/keyspace-notifications.js
+++ b/src/keyspace-notifications.js
@@ -40,14 +40,24 @@ export default function parseKeyspaceEvents(keyspaceEventsConfigString) {
   return keyspaceConfig;
 }
 
-export function emitKeyspaceNotification(redisMock, key, event, database = 0) {
-  const channel = `__keyspace@${database}__:${key}`;
-  const message = event;
-  redisMock.publish(channel, message);
-}
-
-export function emitKeyeventNotification(redisMock, key, event, database = 0) {
-  const channel = `__keyevent@${database}__:${event}`;
-  const message = key;
-  redisMock.publish(channel, message);
+export function emitNotification(
+  redisMock,
+  notifType,
+  key,
+  event,
+  database = 0
+) {
+  let channel = null;
+  let message = null;
+  if (redisMock.keyspaceEvents.K[notifType] === true) {
+    channel = `__keyspace@${database}__:${key}`;
+    message = event;
+  }
+  if (redisMock.keyspaceEvents.E[notifType] === true) {
+    channel = `__keyevent@${database}__:${event}`;
+    message = key;
+  }
+  if (channel !== null && message !== null) {
+    redisMock.publish(channel, message);
+  }
 }

--- a/src/keyspace-notifications.js
+++ b/src/keyspace-notifications.js
@@ -1,0 +1,53 @@
+const allEventsDisabled = {
+  g: false,
+  string: false,
+  l: false,
+  s: false,
+  h: false,
+  z: false,
+  x: false,
+  e: false,
+};
+
+function parseEvents(keyspaceEventsConfigString) {
+  const result = Object.assign({}, allEventsDisabled);
+  const allEvents = 'g$lshzxe';
+  const unAliasedString = keyspaceEventsConfigString.replace('A', allEvents);
+  result.g = unAliasedString.includes('g');
+  result.string = unAliasedString.includes('$');
+  result.l = unAliasedString.includes('l');
+  result.s = unAliasedString.includes('s');
+  result.h = unAliasedString.includes('h');
+  result.z = unAliasedString.includes('z');
+  result.x = unAliasedString.includes('x');
+  result.e = unAliasedString.includes('e');
+  return result;
+}
+
+export default function parseKeyspaceEvents(keyspaceEventsConfigString) {
+  const keyspaceConfig = {
+    K: Object.assign({}, allEventsDisabled),
+    E: Object.assign({}, allEventsDisabled),
+  };
+  const isKeyspace = keyspaceEventsConfigString.includes('K');
+  const isKeyevent = keyspaceEventsConfigString.includes('E');
+  if (isKeyspace) {
+    keyspaceConfig.K = parseEvents(keyspaceEventsConfigString);
+  }
+  if (isKeyevent) {
+    keyspaceConfig.E = parseEvents(keyspaceEventsConfigString);
+  }
+  return keyspaceConfig;
+}
+
+export function emitKeyspaceNotification(redisMock, key, event, database = 0) {
+  const channel = `__keyspace@${database}__:${key}`;
+  const message = event;
+  redisMock.publish(channel, message);
+}
+
+export function emitKeyeventNotification(redisMock, key, event, database = 0) {
+  const channel = `__keyevent@${database}__:${event}`;
+  const message = key;
+  redisMock.publish(channel, message);
+}

--- a/test/commands/rename.js
+++ b/test/commands/rename.js
@@ -17,4 +17,27 @@ describe('rename', () => {
         expect(redis.data.get('bar')).toBe('baz');
       });
   });
+
+  it('should emit keyspace notifications if configured', done => {
+    const redis = new MockRedis({ notifyKeyspaceEvents: 'gK' }); // gK: generic Keyspace
+    const redisPubSub = redis.createConnectedClient();
+    let messagesReceived = 0;
+    redisPubSub.on('message', (channel, message) => {
+      messagesReceived++;
+      if (messagesReceived === 1) {
+        expect(channel).toBe('__keyspace@0__:before');
+        expect(message).toBe('rename_from');
+      }
+      if (messagesReceived === 2) {
+        expect(channel).toBe('__keyspace@0__:after');
+        expect(message).toBe('rename_to');
+        done();
+      }
+    });
+    redisPubSub
+      .subscribe('__keyspace@0__:before', '__keyspace@0__:after')
+      .then(() =>
+        redis.set('before', 'value').then(() => redis.rename('before', 'after'))
+      );
+  });
 });

--- a/test/keyspace-notifications.js
+++ b/test/keyspace-notifications.js
@@ -1,0 +1,104 @@
+import expect from 'expect';
+import parseKeyspaceEvents from '../src/keyspace-notifications';
+import MockRedis from '../src';
+
+describe('parseKeyspaceEvents', () => {
+  it('should interpret an empty string as all notifications disabled', () => {
+    const emptyString = '';
+    const notificationConfig = parseKeyspaceEvents(emptyString);
+    expect(notificationConfig.K.g).toBe(false);
+    expect(notificationConfig.K.string).toBe(false);
+    expect(notificationConfig.K.l).toBe(false);
+    expect(notificationConfig.K.s).toBe(false);
+    expect(notificationConfig.K.h).toBe(false);
+    expect(notificationConfig.K.z).toBe(false);
+    expect(notificationConfig.K.x).toBe(false);
+    expect(notificationConfig.K.e).toBe(false);
+    expect(notificationConfig.E.g).toBe(false);
+    expect(notificationConfig.E.string).toBe(false);
+    expect(notificationConfig.E.l).toBe(false);
+    expect(notificationConfig.E.s).toBe(false);
+    expect(notificationConfig.E.h).toBe(false);
+    expect(notificationConfig.E.z).toBe(false);
+    expect(notificationConfig.E.x).toBe(false);
+    expect(notificationConfig.E.e).toBe(false);
+  });
+
+  it('should interpret "gxK" as generic and expired keyspace events', () => {
+    const notificationConfig = parseKeyspaceEvents('gxK');
+    expect(notificationConfig.K.g).toBe(true);
+    expect(notificationConfig.K.string).toBe(false);
+    expect(notificationConfig.K.l).toBe(false);
+    expect(notificationConfig.K.s).toBe(false);
+    expect(notificationConfig.K.h).toBe(false);
+    expect(notificationConfig.K.z).toBe(false);
+    expect(notificationConfig.K.x).toBe(true);
+    expect(notificationConfig.K.e).toBe(false);
+    expect(notificationConfig.E.g).toBe(false);
+    expect(notificationConfig.E.string).toBe(false);
+    expect(notificationConfig.E.l).toBe(false);
+    expect(notificationConfig.E.s).toBe(false);
+    expect(notificationConfig.E.h).toBe(false);
+    expect(notificationConfig.E.z).toBe(false);
+    expect(notificationConfig.E.x).toBe(false);
+    expect(notificationConfig.E.e).toBe(false);
+  });
+
+  it('should interpret "AKE" as all notifications enabled', () => {
+    const notificationConfig = parseKeyspaceEvents('AKE');
+    expect(notificationConfig.K.g).toBe(true);
+    expect(notificationConfig.K.string).toBe(true);
+    expect(notificationConfig.K.l).toBe(true);
+    expect(notificationConfig.K.s).toBe(true);
+    expect(notificationConfig.K.h).toBe(true);
+    expect(notificationConfig.K.z).toBe(true);
+    expect(notificationConfig.K.x).toBe(true);
+    expect(notificationConfig.K.e).toBe(true);
+    expect(notificationConfig.E.g).toBe(true);
+    expect(notificationConfig.E.string).toBe(true);
+    expect(notificationConfig.E.l).toBe(true);
+    expect(notificationConfig.E.s).toBe(true);
+    expect(notificationConfig.E.h).toBe(true);
+    expect(notificationConfig.E.z).toBe(true);
+    expect(notificationConfig.E.x).toBe(true);
+    expect(notificationConfig.E.e).toBe(true);
+  });
+});
+
+describe('keyspaceNotifications', () => {
+  it('should appear when configured and the triggering event occurs', done => {
+    const redis = new MockRedis({ notifyKeyspaceEvents: 'gK' }); // gK: generic keyspace
+    const redisPubSub = redis.createConnectedClient();
+    redisPubSub.on('message', (channel, message) => {
+      expect(channel).toBe('__keyspace@0__:key');
+      expect(message).toBe('del');
+      done();
+    });
+    redisPubSub
+      .subscribe('__keyspace@0__:key')
+      .then(() => redis.set('key', 'value').then(() => redis.del('key')));
+  });
+
+  it('should not appear when not configured and the triggering event occurs', done => {
+    const redis = new MockRedis({ notifyKeyspaceEvents: '' }); // empty string: not configured
+    redis.on('message', (channel, message) => {
+      throw new Error(`should not receive ${message} on ${channel}`);
+    });
+    redis.set('key', 'value').then(() => redis.del('key'));
+    // wait for notification to NOT appear
+    setTimeout(() => done(), 40);
+  });
+
+  it('should appear on a connected second mock instance when configured and the triggering event occurs', done => {
+    const redis = new MockRedis({ notifyKeyspaceEvents: 'gK' }); // gK: generic keyspace
+    const redis2 = redis.createConnectedClient({ notifyKeyspaceEvents: 'gK' });
+    redis2.on('message', (channel, message) => {
+      expect(channel).toBe('__keyspace@0__:key');
+      expect(message).toBe('del');
+      done();
+    });
+    redis2
+      .subscribe('__keyspace@0__:key')
+      .then(() => redis.set('key', 'value').then(() => redis.del('key')));
+  });
+});

--- a/test/keyspace-notifications.js
+++ b/test/keyspace-notifications.js
@@ -102,3 +102,18 @@ describe('keyspaceNotifications', () => {
       .then(() => redis.set('key', 'value').then(() => redis.del('key')));
   });
 });
+
+describe('keyeventNotifications', () => {
+  it('should appear when configured and the triggering event occurs', done => {
+    const redis = new MockRedis({ notifyKeyspaceEvents: 'gE' }); // gK: generic keyevent
+    const redisPubSub = redis.createConnectedClient();
+    redisPubSub.on('message', (channel, message) => {
+      expect(channel).toBe('__keyevent@0__:del');
+      expect(message).toBe('key');
+      done();
+    });
+    redisPubSub
+      .subscribe('__keyevent@0__:del')
+      .then(() => redis.set('key', 'value').then(() => redis.del('key')));
+  });
+});


### PR DESCRIPTION
implemented: 
K     Keyspace events, published with __keyspace@<db>__ prefix.
E     Keyevent events, published with __keyevent@<db>__ prefix.
g     Generic commands (non-type specific) like DEL, EXPIRE, RENAME, ...
A     Alias for g$lshzxe, so that the "AKE" string means all the events.


NOT implemented - but could be added in future:
$     String commands
l     List commands
s     Set commands
h     Hash commands
z     Sorted set commands
x     Expired events (events generated every time a key expires)
e     Evicted events (events generated when a key is evicted for maxmemory)
