### PR TITLE
fix: nextCursor in scan must be string

### DIFF
--- a/src/commands-utils/readable-scan.js
+++ b/src/commands-utils/readable-scan.js
@@ -31,7 +31,7 @@ export default class ReadableScan extends Readable {
     this._callScan()
       .then(res => {
         const [nextCursor, keys] = res;
-        if (nextCursor === 0) {
+        if (nextCursor === '0') {
           this._drained = true;
         } else {
           this._cursor = nextCursor;

--- a/src/commands-utils/scan-command.common.js
+++ b/src/commands-utils/scan-command.common.js
@@ -67,5 +67,5 @@ export function scanHelper(allKeys, size, cursorStart, ...args) {
     nextCursor = 0;
   }
 
-  return [nextCursor, keys];
+  return [String(nextCursor), keys];
 }

--- a/src/commands/hscan.js
+++ b/src/commands/hscan.js
@@ -2,7 +2,7 @@ import { scanHelper } from '../commands-utils/scan-command.common';
 
 export function hscan(key, cursor, ...args) {
   if (!this.data.has(key)) {
-    return [0, []];
+    return ['0', []];
   }
   const hKeys = Object.keys(this.data.get(key));
   return scanHelper(hKeys, 1, cursor, ...args);

--- a/src/commands/sscan.js
+++ b/src/commands/sscan.js
@@ -2,7 +2,7 @@ import { scanHelper } from '../commands-utils/scan-command.common';
 
 export function sscan(key, cursor, ...args) {
   if (!this.data.has(key)) {
-    return [0, []];
+    return ['0', []];
   }
   const setKeys = [];
   this.data.get(key).forEach(value => setKeys.push(value));

--- a/src/commands/zscan.js
+++ b/src/commands/zscan.js
@@ -2,7 +2,7 @@ import { scanHelper } from '../commands-utils/scan-command.common';
 
 export function zscan(key, cursor, ...args) {
   if (!this.data.has(key)) {
-    return [0, []];
+    return ['0', []];
   }
   const zKeys = [];
   this.data.get(key).forEach((_, mkey) => zKeys.push(mkey));

--- a/test/commands/hscan.js
+++ b/test/commands/hscan.js
@@ -16,7 +16,7 @@ describe('hscan', () => {
   it('should return null array if hset does not exist', () => {
     const redis = new MockRedis();
     return redis.hscan('key', 0).then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual([]);
     });
   });
@@ -29,7 +29,7 @@ describe('hscan', () => {
     });
 
     return redis.hscan('hset', 0).then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo', 'bar', 'baz']);
     });
   });
@@ -42,7 +42,7 @@ describe('hscan', () => {
     });
 
     return redis.hscan('hset', 0, 'MATCH', 'foo*').then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo0', 'foo1', 'foo2']);
     });
   });
@@ -57,12 +57,12 @@ describe('hscan', () => {
     return redis
       .hscan('hset', 0, 'MATCH', 'foo*', 'COUNT', 1)
       .then(result => {
-        expect(result[0]).toBe(1); // more elements left, this is why cursor is not 0
+        expect(result[0]).toBe('1'); // more elements left, this is why cursor is not 0
         expect(result[1]).toEqual(['foo0']);
         return redis.hscan('hset', result[0], 'MATCH', 'foo*', 'COUNT', 10);
       })
       .then(result2 => {
-        expect(result2[0]).toBe(0);
+        expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['foo1', 'foo2']);
       });
   });
@@ -77,12 +77,12 @@ describe('hscan', () => {
     return redis
       .hscan('hset', 0, 'COUNT', 3)
       .then(result => {
-        expect(result[0]).toBe(3);
+        expect(result[0]).toBe('3');
         expect(result[1]).toEqual(['foo0', 'foo1', 'bar0']);
         return redis.hscan('hset', result[0], 'COUNT', 3);
       })
       .then(result2 => {
-        expect(result2[0]).toBe(0);
+        expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['bar1']);
       });
   });

--- a/test/commands/scan.js
+++ b/test/commands/scan.js
@@ -5,7 +5,7 @@ describe('scan', () => {
   it('should return null array if nothing in db', () => {
     const redis = new MockRedis();
     return redis.scan(0).then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual([]);
     });
   });
@@ -19,7 +19,7 @@ describe('scan', () => {
     });
 
     return redis.scan(0).then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo', 'test']);
     });
   });
@@ -65,7 +65,7 @@ describe('scan', () => {
     });
 
     return redis.scan(0, 'MATCH', 'foo*').then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo0', 'foo1', 'foo2']);
     });
   });
@@ -83,12 +83,12 @@ describe('scan', () => {
     return redis
       .scan(0, 'MATCH', 'foo*', 'COUNT', 1)
       .then(result => {
-        expect(result[0]).toBe(1); // more elements left, this is why cursor is not 0
+        expect(result[0]).toBe('1'); // more elements left, this is why cursor is not 0
         expect(result[1]).toEqual(['foo0']);
         return redis.scan(result[0], 'MATCH', 'foo*', 'COUNT', 10);
       })
       .then(result2 => {
-        expect(result2[0]).toBe(0);
+        expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['foo1', 'foo2']);
       });
   });
@@ -105,12 +105,12 @@ describe('scan', () => {
     return redis
       .scan(0, 'COUNT', 3)
       .then(result => {
-        expect(result[0]).toBe(3);
+        expect(result[0]).toBe('3');
         expect(result[1]).toEqual(['foo0', 'foo1', 'test0']);
         return redis.scan(result[0], 'COUNT', 3);
       })
       .then(result2 => {
-        expect(result2[0]).toBe(0);
+        expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['test1']);
       });
   });

--- a/test/commands/sscan.js
+++ b/test/commands/sscan.js
@@ -6,7 +6,7 @@ describe('sscan', () => {
   it('should return null array if set does not exist', () => {
     const redis = new MockRedis();
     return redis.sscan('key', 0).then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual([]);
     });
   });
@@ -19,7 +19,7 @@ describe('sscan', () => {
     });
 
     return redis.sscan('set', 0).then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo', 'bar', 'baz']);
     });
   });
@@ -32,7 +32,7 @@ describe('sscan', () => {
     });
 
     return redis.sscan('set', 0, 'MATCH', 'foo*').then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo0', 'foo1', 'foo2']);
     });
   });
@@ -47,12 +47,12 @@ describe('sscan', () => {
     return redis
       .sscan('set', 0, 'MATCH', 'foo*', 'COUNT', 1)
       .then(result => {
-        expect(result[0]).toBe(1); // more elements left, this is why cursor is not 0
+        expect(result[0]).toBe('1'); // more elements left, this is why cursor is not 0
         expect(result[1]).toEqual(['foo0']);
         return redis.sscan('set', result[0], 'MATCH', 'foo*', 'COUNT', 10);
       })
       .then(result2 => {
-        expect(result2[0]).toBe(0);
+        expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['foo1', 'foo2']);
       });
   });
@@ -67,12 +67,12 @@ describe('sscan', () => {
     return redis
       .sscan('set', 0, 'COUNT', 3)
       .then(result => {
-        expect(result[0]).toBe(3);
+        expect(result[0]).toBe('3');
         expect(result[1]).toEqual(['foo0', 'foo1', 'bar0']);
         return redis.sscan('set', result[0], 'COUNT', 3);
       })
       .then(result2 => {
-        expect(result2[0]).toBe(0);
+        expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['bar1']);
       });
   });

--- a/test/commands/zscan.js
+++ b/test/commands/zscan.js
@@ -10,7 +10,7 @@ describe('zscan', () => {
   it('should return null array if zset does not exist', () => {
     const redis = new MockRedis();
     return redis.zscan('key', 0).then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual([]);
     });
   });
@@ -23,7 +23,7 @@ describe('zscan', () => {
     });
 
     return redis.zscan('zset', 0).then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo', 'bar', 'baz']);
     });
   });
@@ -36,7 +36,7 @@ describe('zscan', () => {
     });
 
     return redis.zscan('zset', 0, 'MATCH', 'foo*').then(result => {
-      expect(result[0]).toBe(0);
+      expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo0', 'foo1', 'foo2']);
     });
   });
@@ -51,12 +51,12 @@ describe('zscan', () => {
     return redis
       .zscan('zset', 0, 'MATCH', 'foo*', 'COUNT', 1)
       .then(result => {
-        expect(result[0]).toBe(1); // more elements left, this is why cursor is not 0
+        expect(result[0]).toBe('1'); // more elements left, this is why cursor is not 0
         expect(result[1]).toEqual(['foo0']);
         return redis.zscan('zset', result[0], 'MATCH', 'foo*', 'COUNT', 10);
       })
       .then(result2 => {
-        expect(result2[0]).toBe(0);
+        expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['foo1', 'foo2']);
       });
   });
@@ -71,12 +71,12 @@ describe('zscan', () => {
     return redis
       .zscan('zset', 0, 'COUNT', 3)
       .then(result => {
-        expect(result[0]).toBe(3);
+        expect(result[0]).toBe('3');
         expect(result[1]).toEqual(['foo0', 'foo1', 'bar0']);
         return redis.zscan('zset', result[0], 'COUNT', 3);
       })
       .then(result2 => {
-        expect(result2[0]).toBe(0);
+        expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['bar1']);
       });
   });


### PR DESCRIPTION
Hi, 
In `ioredis` all `*scan` commands returns nextCursor as string. In this PR I add same logic for ioredis-mock, because some 3prt utils have strict comparison to '0'.

Please, review it, and release new version if it posible. Thanks!