### PR TITLE
feat: add unlink command

### DIFF
--- a/compat.md
+++ b/compat.md
@@ -148,6 +148,7 @@
 | [touch](http://redis.io/commands/TOUCH)                               | :white_check_mark: |        :x:         |
 | [ttl](http://redis.io/commands/TTL)                                   | :white_check_mark: | :white_check_mark: |
 | [type](http://redis.io/commands/TYPE)                                 | :white_check_mark: | :white_check_mark: |
+| [unlink](http://redis.io/commands/UNLINK)                             | :white_check_mark: | :white_check_mark: |
 | [unsubscribe](http://redis.io/commands/UNSUBSCRIBE)                   | :white_check_mark: | :white_check_mark: |
 | [unwatch](http://redis.io/commands/UNWATCH)                           | :white_check_mark: |        :x:         |
 | [wait](http://redis.io/commands/WAIT)                                 | :white_check_mark: |        :x:         |

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -96,6 +96,7 @@ export * from './time';
 export * from './ttl';
 export * from './type';
 export * from './unsubscribe';
+export * from './unlink';
 export * from './xadd';
 export * from './xlen';
 export * from './xrange';

--- a/src/commands/unlink.js
+++ b/src/commands/unlink.js
@@ -1,0 +1,6 @@
+import { del } from './del';
+
+export function unlink(...keys) {
+  const removeKeys = del.bind(this);
+  return removeKeys(...keys);
+}

--- a/test/commands/unlink.js
+++ b/test/commands/unlink.js
@@ -1,0 +1,20 @@
+import expect from 'expect';
+
+import MockRedis from '../../src';
+
+describe('unlink', () => {
+  const redis = new MockRedis({
+    data: {
+      unlinkme: 'please',
+      metoo: 'pretty please',
+    },
+  });
+  it('should unlink/delete passed in keys', () =>
+    redis
+      .unlink('unlinkme', 'metoo')
+      .then(status => expect(status).toBe(2))
+      .then(() => expect(redis.data.has('unlinkme')).toBe(false))
+      .then(() => expect(redis.data.has('metoo')).toBe(false)));
+  it('should return the number of keys unlinked', () =>
+    redis.unlink('deleteme', 'metoo').then(status => expect(status).toBe(0)));
+});


### PR DESCRIPTION
- Adds support for the `unlink` command.
- Delegates off to `del` as the behavior when running in memory would behave the same. I have verified that `unlink` sends the same keyspace notifications as `del` too. 

Fixes #746