### PR TITLE
fix: changed hset functionality to act as hmset

### DIFF
--- a/src/commands/hset.js
+++ b/src/commands/hset.js
@@ -1,16 +1,14 @@
-export function hset(key, hashKey, hashVal) {
+export function hset(key, ...args) {
   if (!this.data.has(key)) {
     this.data.set(key, {});
   }
 
-  let reply = 1;
+  let reply = 0;
   const hash = this.data.get(key);
-
-  if ({}.hasOwnProperty.call(hash, hashKey)) {
-    reply = 0;
+  for (let i = 0; i < args.length; i += 2) {
+    if (!{}.hasOwnProperty.call(hash, args[i])) reply++;
+    hash[args[i]] = args[i + 1];
   }
-
-  hash[hashKey] = hashVal;
 
   this.data.set(key, hash);
 

--- a/test/commands/hset.js
+++ b/test/commands/hset.js
@@ -24,4 +24,20 @@ describe('hset', () => {
           email: 'bruce@wayne.enterprises',
         })
       ));
+
+  it('should let you set multiple hash map keys and values in a single command', () => {
+    const hash = { id: '2', email: 'bruce@wayne.enterprises' };
+    return redis
+      .hset('user:2', 'id', '2', 'email', 'bruce@wayne.enterprises')
+      .then(status => expect(status).toBe(2))
+      .then(() => expect(redis.data.get('user:2')).toEqual(hash));
+  });
+
+  it('should let you set multiple hash map keys and values with an object', () => {
+    const hash = { id: '3', email: 'bruce@wayne.enterprises' };
+    return redis
+      .hset('user:3', hash)
+      .then(status => expect(status).toBe(1))
+      .then(() => expect(redis.data.get('user:3')).toEqual(hash));
+  });
 });


### PR DESCRIPTION
I have tried to add hmset functionality to hset. However, I have encountered that hset is not receiving an argument in a form of an object. I am not sure what causes that issue, but it seems that hset receives string insead of an object. 
`  Error: Expected { '[object Object]': undefined } to equal { id: '3', email: 'bruce@wayne.enterprises' }`
 
If anyone can check what is the possible issue for that, and maybe a fix, this pull request should work

Fixes [Issue #345](https://github.com/stipsan/ioredis-mock/issues/345)