### PR TITLE
feat: implement lua redis.pcall

### DIFF
--- a/test/commands/eval.js
+++ b/test/commands/eval.js
@@ -26,4 +26,22 @@ describe('eval', () => {
           .then(result => expect(result).toEqual(3005));
       });
   });
+
+  it('should be able to ignore errors from pcall', () => {
+    const redis = new MockRedis();
+    const NUMBER_OF_KEYS = 1;
+    const KEY1 = 'KEY1';
+
+    return redis.set(KEY1, 10).then(() => {
+      const luaScript = `
+          local before = redis.pcall('GET', KEYS[1])
+          redis.pcall('invalid command')
+          return before
+        `;
+
+      return redis
+        .eval(luaScript, NUMBER_OF_KEYS, KEY1)
+        .then(result => expect(result).toEqual(10));
+    });
+  });
 });

--- a/test/lua.js
+++ b/test/lua.js
@@ -102,7 +102,7 @@ describe('lua', () => {
         `);
 
         // expect it was called and we can get the right arguments
-        expect(wasCalledWith).toEqual([3, 'EXISTS', 'PEPE', 'THIRD']);
+        expect(wasCalledWith).toEqual([false, 'EXISTS', 'PEPE', 'THIRD']);
       });
     });
 


### PR DESCRIPTION
redis.pcall is the same as redis.call, but, if an internal error
of any kind happens, it returns 'a table', instead of failing.

It's unclear from the docs what this table is supposed to be.

The only place I've seen pcall used is in redlock, which ignores
the return value:

https://github.com/mike-marcacci/node-redlock/blob/e90e80a611c83a6a8c16912c7c5a8c6e9d49c617/redlock.js#L31

This is sufficient for redlock to "work" during our tests. Whether it's actually effective or not is a different matter. :)