### PR TITLE
fix: z(rev)?rangebyscore does not support negative limit count (#939)

### DIFF
--- a/src/commands/zrange-command.common.js
+++ b/src/commands/zrange-command.common.js
@@ -19,6 +19,21 @@ export function slice(arr, s, e) {
   return arr.slice(start, end + 1);
 }
 
+function normalizeCountToIndex(offset, count, array) {
+  if (count < 0) {
+    return -count > array.length ? 0 : array.length + count;
+  }
+  return offset + count;
+}
+
+export function offsetAndLimit(arr, offset, count) {
+  if (count === 0) {
+    return [];
+  }
+  const end = normalizeCountToIndex(offset, count, arr);
+  return arr.slice(offset, end);
+}
+
 export function parseLimit(input) {
   let str = `${input}`;
   let strict = false;

--- a/src/commands/zrangebyscore.js
+++ b/src/commands/zrangebyscore.js
@@ -5,6 +5,7 @@ import {
   parseLimit,
   filterPredicate,
   getWithScoresAndLimit,
+  offsetAndLimit,
 } from './zrange-command.common';
 
 export function zrangebyscore(key, inputMin, inputMax, ...args) {
@@ -26,19 +27,18 @@ export function zrangebyscore(key, inputMin, inputMax, ...args) {
     filterPredicate(min, max)
   );
 
-  const ordered = orderBy(filteredArray, ['score', 'value']);
+  let ordered = orderBy(filteredArray, ['score', 'value']);
   if (withScores) {
-    const results = flatMap(ordered, it => [it.value, it.score]);
-
-    if (limit) {
-      return results.slice(offset * 2, (offset + limit) * 2);
+    if (limit !== null) {
+      ordered = offsetAndLimit(ordered, offset, limit);
     }
-    return results;
+
+    return flatMap(ordered, it => [it.value, it.score]);
   }
 
   const results = ordered.map(it => it.value);
-  if (limit) {
-    return results.slice(offset, offset + limit);
+  if (limit !== null) {
+    return offsetAndLimit(results, offset, limit);
   }
   return results;
 }

--- a/src/commands/zrevrangebyscore.js
+++ b/src/commands/zrevrangebyscore.js
@@ -5,6 +5,7 @@ import {
   parseLimit,
   filterPredicate,
   getWithScoresAndLimit,
+  offsetAndLimit,
 } from './zrange-command.common';
 
 export function zrevrangebyscore(key, inputMax, inputMin, ...args) {
@@ -26,20 +27,18 @@ export function zrevrangebyscore(key, inputMax, inputMin, ...args) {
     filterPredicate(min, max)
   );
 
-  const ordered = orderBy(filteredArray, ['score', 'value'], ['desc', 'desc']);
+  let ordered = orderBy(filteredArray, ['score', 'value'], ['desc', 'desc']);
   if (withScores) {
-    const results = flatMap(ordered, it => [it.value, it.score]);
-
-    if (limit) {
-      return results.slice(offset * 2, (offset + limit) * 2);
+    if (limit !== null) {
+      ordered = offsetAndLimit(ordered, offset, limit);
     }
 
-    return results;
+    return flatMap(ordered, it => [it.value, it.score]);
   }
 
   const results = ordered.map(it => it.value);
-  if (limit) {
-    return results.slice(offset, offset + limit);
+  if (limit !== null) {
+    return offsetAndLimit(results, offset, limit);
   }
   return results;
 }

--- a/test/commands/zrangebyscore.js
+++ b/test/commands/zrangebyscore.js
@@ -116,4 +116,28 @@ describe('zrangebyscore', () => {
       .zrangebyscore('foo', 1, 3, 'LIMIT', 1, 1, 'WITHSCORES')
       .then(res => expect(res).toEqual(['second', 2]));
   });
+  it('should handle LIMIT of -1', () => {
+    const redis = new MockRedis({ data });
+    return redis
+      .zrangebyscore('foo', '-inf', '+inf', 'LIMIT', 1, -1)
+      .then(res => expect(res).toEqual(['second', 'third', 'fourth']));
+  });
+  it('should handle LIMIT of -1 and WITHSCORES', () => {
+    const redis = new MockRedis({ data });
+    return redis
+      .zrangebyscore('foo', '-inf', '+inf', 'LIMIT', 1, -1, 'WITHSCORES')
+      .then(res => expect(res).toEqual(['second', 2, 'third', 3, 'fourth', 4]));
+  });
+  it('should handle LIMIT of -2', () => {
+    const redis = new MockRedis({ data });
+    return redis
+      .zrangebyscore('foo', '-inf', '+inf', 'LIMIT', 1, -2)
+      .then(res => expect(res).toEqual(['second', 'third']));
+  });
+  it('should handle LIMIT of 0', () => {
+    const redis = new MockRedis({ data });
+    return redis
+      .zrangebyscore('foo', '-inf', '+inf', 'LIMIT', 1, 0)
+      .then(res => expect(res).toEqual([]));
+  });
 });

--- a/test/commands/zrevrangebyscore.js
+++ b/test/commands/zrevrangebyscore.js
@@ -117,4 +117,28 @@ describe('zrevrangebyscore', () => {
       .zrevrangebyscore('foo', 3, 1, 'LIMIT', 1, 1, 'WITHSCORES')
       .then(res => expect(res).toEqual(['second', 2]));
   });
+  it('should handle LIMIT of -1', () => {
+    const redis = new MockRedis({ data });
+    return redis
+      .zrevrangebyscore('foo', '+inf', '-inf', 'LIMIT', 1, -1)
+      .then(res => expect(res).toEqual(['fourth', 'third', 'second']));
+  });
+  it('should handle LIMIT of -1 and WITHSCORES', () => {
+    const redis = new MockRedis({ data });
+    return redis
+      .zrevrangebyscore('foo', '+inf', '-inf', 'LIMIT', 1, -1, 'WITHSCORES')
+      .then(res => expect(res).toEqual(['fourth', 4, 'third', 3, 'second', 2]));
+  });
+  it('should handle LIMIT of -2', () => {
+    const redis = new MockRedis({ data });
+    return redis
+      .zrevrangebyscore('foo', '+inf', '-inf', 'LIMIT', 1, -2)
+      .then(res => expect(res).toEqual(['fourth', 'third']));
+  });
+  it('should handle LIMIT of 0', () => {
+    const redis = new MockRedis({ data });
+    return redis
+      .zrevrangebyscore('foo', '+inf', '-inf', 'LIMIT', 1, 0)
+      .then(res => expect(res).toEqual([]));
+  });
 });


### PR DESCRIPTION
Fixes #939