### PR TITLE
Fixes #877: DECR and DECRBY defaults value if key doesn't exist

### DIFF
--- a/src/commands/decr.js
+++ b/src/commands/decr.js
@@ -1,4 +1,7 @@
 export function decr(key) {
+  if (!this.data.has(key)) {
+    this.data.set(key, '0');
+  }
   const curVal = Number(this.data.get(key));
   const nextVal = curVal - 1;
   this.data.set(key, nextVal.toString());

--- a/src/commands/decrby.js
+++ b/src/commands/decrby.js
@@ -1,4 +1,7 @@
 export function decrby(key, decrement = 0) {
+  if (!this.data.has(key)) {
+    this.data.set(key, '0');
+  }
   const curVal = Number(this.data.get(key));
   const nextVal = curVal - parseInt(decrement, 10);
   this.data.set(key, nextVal.toString());


### PR DESCRIPTION
As reported in #877

Related docs:
* https://redis.io/commands/decr
* https://redis.io/commands/decrby

The setting of default key-value is already done in the `incr` and `incrby` commands. This PR brings that logic to the decrement commands.

Thanks