### PR TITLE
fix: ioredis getset doesn't return null when saving new sets

### DIFF
--- a/src/commands/getset.js
+++ b/src/commands/getset.js
@@ -1,5 +1,5 @@
 export function getset(key, val) {
-  const old = this.data.has(key) ? this.data.get(key) : '';
+  const old = this.data.has(key) ? this.data.get(key) : null;
   this.data.set(key, val);
   this.expires.delete(key);
   return old;

--- a/test/commands/getset.js
+++ b/test/commands/getset.js
@@ -11,7 +11,16 @@ describe('getset', () => {
     });
     return redis
       .getset('foo', 'World')
-      .then(result => expect(result).toBe('Hello'))
+      .then((result) => expect(result).toBe('Hello'))
+      .then(() => expect(redis.data.get('foo')).toBe('World'));
+  });
+  it('should set the new value and return null when does not have an old value', () => {
+    const redis = new MockRedis({
+      data: {},
+    });
+    return redis
+      .getset('foo', 'World')
+      .then((result) => expect(result).toBe(null))
       .then(() => expect(redis.data.get('foo')).toBe('World'));
   });
 });


### PR DESCRIPTION
Return null for getset when is a new data set

More details on the issue: https://github.com/stipsan/ioredis-mock/issues/973