### PR TITLE
chore: only validate PR titles

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,1 @@
+titleOnly: true


### PR DESCRIPTION
This should stop blocking #987, #979, and #974