### PR TITLE
fix: Make zscan and zscanStream match ioredis behaviour

### DIFF
--- a/src/commands/zscan.js
+++ b/src/commands/zscan.js
@@ -1,3 +1,4 @@
+import { flatten } from 'lodash';
 import { scanHelper } from '../commands-utils/scan-command.common';
 
 export function zscan(key, cursor, ...args) {
@@ -5,6 +6,11 @@ export function zscan(key, cursor, ...args) {
     return ['0', []];
   }
   const zKeys = [];
-  this.data.get(key).forEach((_, mkey) => zKeys.push(mkey));
-  return scanHelper(zKeys, 1, cursor, ...args);
+
+  this.data.get(key).forEach(({ score, value }) => {
+    zKeys.push([value, score.toString()]);
+  });
+
+  const [offset, keys] = scanHelper(zKeys, 1, cursor, ...args);
+  return [offset, flatten(keys)];
 }

--- a/test/commands/zscan.js
+++ b/test/commands/zscan.js
@@ -4,12 +4,12 @@ import MockRedis from '../../src';
 
 describe('zscan', () => {
   function createMap(keys) {
-    return new Map(keys.map(k => [k, { score: 0, value: k }]));
+    return new Map(keys.map((k) => [k, { score: 0, value: k }]));
   }
 
   it('should return null array if zset does not exist', () => {
     const redis = new MockRedis();
-    return redis.zscan('key', 0).then(result => {
+    return redis.zscan('key', 0).then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual([]);
     });
@@ -22,26 +22,26 @@ describe('zscan', () => {
       },
     });
 
-    return redis.zscan('zset', 0).then(result => {
+    return redis.zscan('zset', 0).then((result) => {
       expect(result[0]).toBe('0');
-      expect(result[1]).toEqual(['foo', 'bar', 'baz']);
+      expect(result[1]).toEqual(['foo', '0', 'bar', '0', 'baz', '0']);
     });
   });
 
-  it('should return only mathced keys', () => {
+  it('should return only matched keys', () => {
     const redis = new MockRedis({
       data: {
         zset: createMap(['foo0', 'foo1', 'foo2', 'ZU0', 'ZU1']),
       },
     });
 
-    return redis.zscan('zset', 0, 'MATCH', 'foo*').then(result => {
+    return redis.zscan('zset', 0, 'MATCH', 'foo*').then((result) => {
       expect(result[0]).toBe('0');
-      expect(result[1]).toEqual(['foo0', 'foo1', 'foo2']);
+      expect(result[1]).toEqual(['foo0', '0', 'foo1', '0', 'foo2', '0']);
     });
   });
 
-  it('should return only mathced keys and limit by COUNT', () => {
+  it('should return only matched keys and limit by COUNT', () => {
     const redis = new MockRedis({
       data: {
         zset: createMap(['foo0', 'foo1', 'foo2', 'ZU0', 'ZU1']),
@@ -50,14 +50,14 @@ describe('zscan', () => {
 
     return redis
       .zscan('zset', 0, 'MATCH', 'foo*', 'COUNT', 1)
-      .then(result => {
+      .then((result) => {
         expect(result[0]).toBe('1'); // more elements left, this is why cursor is not 0
-        expect(result[1]).toEqual(['foo0']);
+        expect(result[1]).toEqual(['foo0', '0']);
         return redis.zscan('zset', result[0], 'MATCH', 'foo*', 'COUNT', 10);
       })
-      .then(result2 => {
+      .then((result2) => {
         expect(result2[0]).toBe('0');
-        expect(result2[1]).toEqual(['foo1', 'foo2']);
+        expect(result2[1]).toEqual(['foo1', '0', 'foo2', '0']);
       });
   });
 
@@ -70,44 +70,44 @@ describe('zscan', () => {
 
     return redis
       .zscan('zset', 0, 'COUNT', 3)
-      .then(result => {
+      .then((result) => {
         expect(result[0]).toBe('3');
-        expect(result[1]).toEqual(['foo0', 'foo1', 'bar0']);
+        expect(result[1]).toEqual(['foo0', '0', 'foo1', '0', 'bar0', '0']);
         return redis.zscan('zset', result[0], 'COUNT', 3);
       })
-      .then(result2 => {
+      .then((result2) => {
         expect(result2[0]).toBe('0');
-        expect(result2[1]).toEqual(['bar1']);
+        expect(result2[1]).toEqual(['bar1', '0']);
       });
   });
 
   it('should fail if incorrect cursor', () => {
     const redis = new MockRedis();
-    return redis.zscan('key', 'ZU').catch(result => {
+    return redis.zscan('key', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect command', () => {
     const redis = new MockRedis();
-    return redis.zscan('key', 0, 'ZU').catch(result => {
+    return redis.zscan('key', 0, 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect MATCH usage', () => {
     const redis = new MockRedis();
-    return redis.zscan('key', 0, 'MATCH', 'pattern', 'ZU').catch(result => {
+    return redis.zscan('key', 0, 'MATCH', 'pattern', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect COUNT usage', () => {
     const redis = new MockRedis();
-    return redis.zscan('key', 0, 'COUNT', 10, 'ZU').catch(result => {
+    return redis.zscan('key', 0, 'COUNT', 10, 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect COUNT usage 2', () => {
     const redis = new MockRedis();
-    return redis.zscan('key', 0, 'COUNT', 'ZU').catch(result => {
+    return redis.zscan('key', 0, 'COUNT', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
@@ -115,7 +115,7 @@ describe('zscan', () => {
     const redis = new MockRedis();
     return redis
       .zscan('key', 0, 'MATCH', 'foo*', 'COUNT', 1, 'ZU')
-      .catch(result => {
+      .catch((result) => {
         expect(result).toBeA(Error);
         expect(result.message).toEqual('Too many arguments');
       });
@@ -123,11 +123,21 @@ describe('zscan', () => {
 
   it('should fail if arguments length not odd', () => {
     const redis = new MockRedis();
-    return redis.zscan('key', 0, 'MATCH', 'foo*', 'COUNT').catch(result => {
+    return redis.zscan('key', 0, 'MATCH', 'foo*', 'COUNT').catch((result) => {
       expect(result).toBeA(Error);
       expect(result.message).toEqual(
         'Args should be provided by pair (name & value)'
       );
+    });
+  });
+
+  it('should match ioredis behaviour', (done) => {
+    const redis = new MockRedis();
+    redis.zadd('test', 1, 'a', 2, 'b', 3, 'c').then(() => {
+      redis.zscan('test', 0).then((replies) => {
+        expect(replies).toEqual(['0', ['a', '1', 'b', '2', 'c', '3']]);
+        done();
+      });
     });
   });
 });

--- a/test/commands/zscanStream.js
+++ b/test/commands/zscanStream.js
@@ -9,14 +9,15 @@ const chance = new Chance();
 
 describe('zscanStream', () => {
   let writable;
-  const flatten = wrt => _.flatten(wrt.data);
-  const createMap = keys => new Map(keys.map(k => [k, { score: 0, value: k }]));
+  const flatten = (wrt) => _.flatten(wrt.data);
+  const createMap = (keys) =>
+    new Map(keys.map((k) => [k, { score: 0, value: k }]));
 
   beforeEach(() => {
     writable = new WritableMock({ objectMode: true });
   });
 
-  it('should return null array if nothing in db', done => {
+  it('should return null array if nothing in db', (done) => {
     // Given
     const redis = new MockRedis();
     const stream = redis.zscanStream('key');
@@ -29,7 +30,7 @@ describe('zscanStream', () => {
     });
   });
 
-  it('should return keys in db', done => {
+  it('should return keys in db', (done) => {
     const redis = new MockRedis({
       data: {
         zset: createMap(['foo', 'bar']),
@@ -40,14 +41,18 @@ describe('zscanStream', () => {
     stream.pipe(writable);
     writable.on('finish', () => {
       // Then
-      expect(flatten(writable)).toEqual(['foo', 'bar']);
+      expect(flatten(writable)).toEqual(['foo', '0', 'bar', '0']);
       done();
     });
   });
 
-  it('should batch by count', done => {
+  it('should batch by count', (done) => {
     // Given
     const keys = chance.unique(chance.word, 100);
+    const keysWithScore = keys.reduce((a, c) => {
+      a.push(c, '0');
+      return a;
+    }, []);
     const count = 11;
     const redis = new MockRedis({ data: { zset: createMap(keys) } });
     const stream = redis.zscanStream('zset', { count });
@@ -56,12 +61,12 @@ describe('zscanStream', () => {
     writable.on('finish', () => {
       // Then
       expect(writable.data.length).toEqual(Math.ceil(keys.length / count));
-      expect(flatten(writable)).toEqual(keys);
+      expect(flatten(writable)).toEqual(keysWithScore);
       done();
     });
   });
 
-  it('should return only mathced keys', done => {
+  it('should return only matched keys', (done) => {
     // Given
     const redis = new MockRedis({
       data: {
@@ -73,12 +78,19 @@ describe('zscanStream', () => {
     stream.pipe(writable);
     writable.on('finish', () => {
       // Then
-      expect(flatten(writable)).toEqual(['foo0', 'foo1', 'foo2']);
+      expect(flatten(writable)).toEqual([
+        'foo0',
+        '0',
+        'foo1',
+        '0',
+        'foo2',
+        '0',
+      ]);
       done();
     });
   });
 
-  it('should return only mathced keys by count', done => {
+  it('should return only matched keys by count', (done) => {
     // Given
     const redis = new MockRedis({
       data: {
@@ -91,12 +103,19 @@ describe('zscanStream', () => {
     writable.on('finish', () => {
       // Then
       expect(writable.data.length).toEqual(Math.ceil(3));
-      expect(flatten(writable)).toEqual(['foo0', 'foo1', 'foo2']);
+      expect(flatten(writable)).toEqual([
+        'foo0',
+        '0',
+        'foo1',
+        '0',
+        'foo2',
+        '0',
+      ]);
       done();
     });
   });
 
-  it('should fail if incorrect count usage', done => {
+  it('should fail if incorrect count usage', (done) => {
     // Given
     const redis = new MockRedis({
       data: {
@@ -106,11 +125,22 @@ describe('zscanStream', () => {
     const stream = redis.zscanStream('zset', { count: 'ZU' });
     // When
     stream.pipe(writable);
-    stream.on('error', err => {
+    stream.on('error', (err) => {
       // Then
       expect(err).toBeA(Error);
       done();
     });
     writable.on('finish', () => done(new Error('should not finish')));
+  });
+
+  it('zscanStream behavior should match ioredis', (done) => {
+    const redis = new MockRedis();
+    redis.zadd('test', 1, 'a', 2, 'b', 3, 'c').then(() => {
+      const stream = redis.zscanStream('test');
+      stream.on('data', (replies) => {
+        expect(replies).toEqual(['a', '1', 'b', '2', 'c', '3']);
+        done();
+      });
+    });
   });
 });


### PR DESCRIPTION
ZSCAN in *ioredis*:
```js
await redis.zadd('test', 1, 'a', 2, 'b', 3, 'c');
redis.zscan('test').then(console.log)
// logs: [ '0', [ 'a', '1', 'b', '2', 'c', '3' ] ]
```

ZSCAN in *ioredis-mock*:
```js
await redis.zadd('test', 1, 'a', 2, 'b', 3, 'c');
redis.zscan('test').then(console.log)
// logs: [ '0', [ 'a', 'b',  'c' ] ]
```
Fixed `zscan` and `zscanStream` implementation and related tests.

Related issue:
https://github.com/stipsan/ioredis-mock/issues/602