### PR TITLE
fix: require node v10 and above

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2
 jobs:
   build:
     docker:
-      - image: circleci/node:10
+      - image: circleci/node:12
     # To support coverage reports from forks
     environment:
       CODECLIMATE_REPO_TOKEN: 688d3234f9bb133fe6efa4dfe74f7a7510f2d9c1dca419875de8257a5f02da45

--- a/.eslintrc
+++ b/.eslintrc
@@ -10,12 +10,15 @@
     "no-plusplus": "off",
     "func-names": "off",
     "no-underscore-dangle": ["error", { "allowAfterThis": true }],
-    "comma-dangle": ["error", {
-      "arrays": "always-multiline",
-      "objects": "always-multiline",
-      "imports": "always-multiline",
-      "exports": "always-multiline",
-      "functions": "never"
-    }]
+    "comma-dangle": [
+      "error",
+      {
+        "arrays": "always-multiline",
+        "objects": "always-multiline",
+        "imports": "always-multiline",
+        "exports": "always-multiline",
+        "functions": "never"
+      }
+    ]
   }
 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
     needs: [build]
     strategy:
       matrix:
-        node_version: [10, 12, 13]
+        node_version: [10, 12, 14, 15]
         os: [ubuntu-latest, windows-latest, macOS-latest]
 
     steps:

--- a/.github/workflows/coveralls.yml
+++ b/.github/workflows/coveralls.yml
@@ -9,25 +9,23 @@ on:
 name: Test Coveralls
 
 jobs:
-
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v1
 
-    - uses: actions/checkout@v1
+      - name: Use Node.js 12.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12.x
 
-    - name: Use Node.js 12.x
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12.x
+      - name: npm install, make test-coverage
+        run: |
+          yarn --frozen-lockfile
+          yarn coverage
 
-    - name: npm install, make test-coverage
-      run: |
-        yarn --frozen-lockfile
-        yarn coverage
-
-    - name: Coveralls
-      uses: coverallsapp/github-action@master
-      with:
-        github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Coveralls
+        uses: coverallsapp/github-action@master
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/updatecompat.yml
+++ b/.github/workflows/updatecompat.yml
@@ -7,30 +7,29 @@ on:
 
 jobs:
   format:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v1
-      with:
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        ref: ${{github.head_ref}}
-    - name: use node.js 12
-      uses: actions/setup-node@v1
-      with:
-        node-version: 12
-    - run: yarn install
-    - run: node scripts/update-compat
-    - name: commit changes
-      run: |
-        git config --local user.email "action@github.com"
-        git config --local user.name "GitHub Action"
-        git add compat.md
-        git commit -m "docs: update feature compat table"
-      continue-on-error: true
-    - name: push changes
-      uses: ad-m/github-push-action@master
-      with:
-        branch: ${{github.head_ref}}
-        repository: ${{ github.event.pull_request.head.repo.full_name }}
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/checkout@v1
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{github.head_ref}}
+      - name: use node.js 12
+        uses: actions/setup-node@v1
+        with:
+          node-version: 12
+      - run: yarn install
+      - run: node scripts/update-compat
+      - name: commit changes
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+          git add compat.md
+          git commit -m "docs: update feature compat table"
+        continue-on-error: true
+      - name: push changes
+        uses: ad-m/github-push-action@master
+        with:
+          branch: ${{github.head_ref}}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,6 @@
 package.json
+package-lock.json
+lib
+.nyc_output
+coverage
+junit

--- a/babel.config.js
+++ b/babel.config.js
@@ -1,3 +1,3 @@
 module.exports = {
-  presets: [['@babel/env', { targets: { node: '0.10.16' } }]],
+  presets: [['@babel/env', { targets: { node: '10' }, bugfixes: true }]],
 };

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "redisjs"
   ],
   "engines": {
-    "node": ">=0.10.16"
+    "node": ">=10"
   },
   "husky": {
     "hooks": {

--- a/scripts/.eslintrc
+++ b/scripts/.eslintrc
@@ -4,8 +4,11 @@
     "node": true
   },
   "rules": {
-    "import/no-extraneous-dependencies": ['error', {
-      "devDependencies": true
-    }]
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
   }
 }

--- a/scripts/update-compat.js
+++ b/scripts/update-compat.js
@@ -21,14 +21,14 @@ const blacklist = [
   'unlink',
 ];
 const filteredCommands = commands.list.filter(
-  command => blacklist.indexOf(command) === -1
+  (command) => blacklist.indexOf(command) === -1
 );
 
 let supportedCommands = 0;
 let tableRows = `
 | redis | ioredis | ioredis-mock |
 |-------|:-------:|:------------:|`;
-filteredCommands.forEach(command => {
+filteredCommands.forEach((command) => {
   const redisCol = `[${command}](http://redis.io/commands/${command.toUpperCase()})`;
   const ioredisCol = command in redis.prototype ? ':white_check_mark:' : ':x:';
   const supportedCommand = command in mockedRedis;
@@ -68,7 +68,7 @@ fs.writeFile(
   path.resolve(__dirname, '..', 'compat.md'),
   prettier.format(tableMd, { parser: 'markdown' }),
   'utf8',
-  err => {
+  (err) => {
     if (err) throw err;
   }
 );
@@ -86,7 +86,7 @@ fs.readFile(readme, 'utf8', (err, readmeMd) => {
         `[![Redis Compatibility: ${percentage}%](https://img.shields.io/badge/redis-${percentage}%25-${color}.svg?style=flat-square)](compat.md)`
       ),
     'utf8',
-    err2 => {
+    (err2) => {
       if (err2) throw err2;
     }
   );

--- a/src/command.js
+++ b/src/command.js
@@ -56,7 +56,7 @@ export function throwIfCommandIsNotAllowed(commandName, RedisMock) {
  * Transform non-buffer arguments to strings to simulate real ioredis behavior
  * @param {any} arg the argument to transform
  */
-const argMapper = arg => {
+const argMapper = (arg) => {
   if (arg === null || arg === undefined) return '';
   return arg instanceof Buffer ? arg : arg.toString();
 };
@@ -116,7 +116,7 @@ export default function command(commandEmulator, commandName, RedisMock) {
     const Promise = promiseContainer.get();
 
     return asCallback(
-      new Promise(resolve =>
+      new Promise((resolve) =>
         resolve(
           safelyExecuteCommand(
             commandEmulator,

--- a/src/commands-utils/readable-scan.js
+++ b/src/commands-utils/readable-scan.js
@@ -29,7 +29,7 @@ export default class ReadableScan extends Readable {
       return;
     }
     this._callScan()
-      .then(res => {
+      .then((res) => {
         const [nextCursor, keys] = res;
         if (nextCursor === '0') {
           this._drained = true;
@@ -39,6 +39,6 @@ export default class ReadableScan extends Readable {
         if (keys.length > 0) this.push(keys);
         else this._read();
       })
-      .catch(err => process.nextTick(() => this.emit('error', err)));
+      .catch((err) => process.nextTick(() => this.emit('error', err)));
   }
 }

--- a/src/commands/brpoplpushBuffer.js
+++ b/src/commands/brpoplpushBuffer.js
@@ -3,5 +3,5 @@ import createBuffer from '../buffer';
 
 export function brpoplpushBuffer(source, destination) {
   const valP = brpoplpush.apply(this, [source, destination]);
-  return valP.then(val => (val ? createBuffer(val) : val));
+  return valP.then((val) => (val ? createBuffer(val) : val));
 }

--- a/src/commands/defineCommand.js
+++ b/src/commands/defineCommand.js
@@ -14,7 +14,7 @@ const { lua, to_luastring: toLuaString } = fengari;
  * ->
  * @param fn - a function returning 0 for non-error and != 0 for error
  */
-export const defineRedisObject = vm => fn => {
+export const defineRedisObject = (vm) => (fn) => {
   vm.defineGlobalFunction(fn, 'call');
 
   // define redis object with call method
@@ -40,7 +40,7 @@ export const defineRedisObject = vm => fn => {
   lua.lua_setglobal(vm.L, toLuaString('redis'));
 };
 
-const callToRedisCommand = vm =>
+const callToRedisCommand = (vm) =>
   function callToRedisCommand2() {
     const rawArgs = vm.extractArgs();
     const returnError = rawArgs[0];

--- a/src/commands/del.js
+++ b/src/commands/del.js
@@ -2,7 +2,7 @@ import { emitNotification } from '../keyspace-notifications';
 
 export function del(...keys) {
   let deleted = 0;
-  keys.forEach(key => {
+  keys.forEach((key) => {
     if (this.data.has(key)) {
       deleted++;
       emitNotification(this, 'g', key, 'del');

--- a/src/commands/hdel.js
+++ b/src/commands/hdel.js
@@ -3,7 +3,7 @@ export function hdel(key, ...fields) {
   if (!value) {
     return 0;
   }
-  const numDeleted = fields.filter(field => {
+  const numDeleted = fields.filter((field) => {
     if ({}.hasOwnProperty.call(value, field)) {
       delete value[field];
       return true;

--- a/src/commands/hgetallBuffer.js
+++ b/src/commands/hgetallBuffer.js
@@ -3,7 +3,7 @@ import createBuffer from '../buffer';
 
 export function hgetallBuffer(key) {
   const val = hgetall.apply(this, [key]);
-  Object.keys(val).forEach(keyInObject => {
+  Object.keys(val).forEach((keyInObject) => {
     val[keyInObject] = createBuffer(val[keyInObject]);
   });
 

--- a/src/commands/hmget.js
+++ b/src/commands/hmget.js
@@ -1,6 +1,6 @@
 export function hmget(key, ...fields) {
   const hash = this.data.get(key);
-  return fields.map(field => {
+  return fields.map((field) => {
     if (!hash || hash[field] === undefined) {
       return null;
     }

--- a/src/commands/hmgetBuffer.js
+++ b/src/commands/hmgetBuffer.js
@@ -3,5 +3,5 @@ import createBuffer from '../buffer';
 
 export function hmgetBuffer(key, ...fields) {
   const val = hmget.apply(this, [key, ...fields]);
-  return val.map(payload => (payload ? createBuffer(payload) : payload));
+  return val.map((payload) => (payload ? createBuffer(payload) : payload));
 }

--- a/src/commands/keys.js
+++ b/src/commands/keys.js
@@ -1,5 +1,5 @@
 import minimatch from 'minimatch';
 
 export function keys(globString) {
-  return this.data.keys().filter(key => minimatch(key, globString));
+  return this.data.keys().filter((key) => minimatch(key, globString));
 }

--- a/src/commands/mget.js
+++ b/src/commands/mget.js
@@ -1,3 +1,3 @@
 export function mget(...keys) {
-  return keys.map(key => (this.data.has(key) ? this.data.get(key) : null));
+  return keys.map((key) => (this.data.has(key) ? this.data.get(key) : null));
 }

--- a/src/commands/psubscribe.js
+++ b/src/commands/psubscribe.js
@@ -4,7 +4,7 @@ import {
 } from '../commands-utils/channel-subscription';
 
 export function psubscribe(...args) {
-  args.forEach(pattern => {
+  args.forEach((pattern) => {
     if (!this.patternChannels.instanceListeners) {
       this.patternChannels.instanceListeners = new Map();
     }

--- a/src/commands/publish.js
+++ b/src/commands/publish.js
@@ -4,8 +4,8 @@ export function publish(channel, message) {
   this.channels.emit(channel, message);
   const matchingPatterns = this.patternChannels
     .eventNames()
-    .filter(pattern => minimatch(channel, pattern));
-  matchingPatterns.forEach(matchingChannel =>
+    .filter((pattern) => minimatch(channel, pattern));
+  matchingPatterns.forEach((matchingChannel) =>
     this.patternChannels.emit(matchingChannel, message, channel)
   );
   const numberOfSubscribers =

--- a/src/commands/punsubscribe.js
+++ b/src/commands/punsubscribe.js
@@ -5,11 +5,11 @@ import {
 
 export function punsubscribe(...args) {
   if (args.length === 0) {
-    getSubscribedChannels(this, this.patternChannels).forEach(channel => {
+    getSubscribedChannels(this, this.patternChannels).forEach((channel) => {
       unsubscribeFromChannel(this, channel, this.patternChannels);
     });
   }
-  args.forEach(pattern => {
+  args.forEach((pattern) => {
     unsubscribeFromChannel(this, pattern, this.patternChannels);
   });
   const numberOfSubscribedChannels = getSubscribedChannels(

--- a/src/commands/sadd.js
+++ b/src/commands/sadd.js
@@ -6,7 +6,7 @@ export function sadd(key, ...vals) {
   }
   let added = 0;
   const set = this.data.get(key);
-  vals.forEach(value => {
+  vals.forEach((value) => {
     if (!set.has(value)) {
       added++;
     }

--- a/src/commands/sdiff.js
+++ b/src/commands/sdiff.js
@@ -5,18 +5,18 @@ export function sdiff(ours, ...theirs) {
   if (this.data.has(ours) && !(this.data.get(ours) instanceof Set)) {
     throw new Error(`Key ${ours} does not contain a set`);
   }
-  theirs.forEach(key => {
+  theirs.forEach((key) => {
     if (this.data.has(key) && !(this.data.get(key) instanceof Set)) {
       throw new Error(`Key ${key} does not contain a set`);
     }
   });
 
   const ourSet = this.data.has(ours) ? this.data.get(ours) : new Set();
-  const theirSets = theirs.map(
-    key => (this.data.has(key) ? this.data.get(key) : new Set())
+  const theirSets = theirs.map((key) =>
+    this.data.has(key) ? this.data.get(key) : new Set()
   );
   const difference = new Set(
-    arrayFrom(ourSet).filter(ourValue =>
+    arrayFrom(ourSet).filter((ourValue) =>
       theirSets.reduce(
         (isUnique, set) => (set.has(ourValue) ? false : isUnique),
         /* isUnique */ true

--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -13,7 +13,7 @@ export function set(key, value, ...options) {
   const nx = options.indexOf('NX') !== -1;
   const xx = options.indexOf('XX') !== -1;
   const filteredOptions = options.filter(
-    option => option !== 'NX' && option !== 'XX'
+    (option) => option !== 'NX' && option !== 'XX'
   );
 
   if (nx && xx) throw new Error('ERR syntax error');

--- a/src/commands/setbit.js
+++ b/src/commands/setbit.js
@@ -1,21 +1,21 @@
 const MAX_OFFSET = 2 ** 32 - 1;
 const STR_BIT_0 = String.fromCharCode(0);
 
-const constantLengthOf = len => str =>
+const constantLengthOf = (len) => (str) =>
   str +
   Array(Math.max(0, len - str.length))
     .fill(STR_BIT_0)
     .join('');
 
 /* eslint-disable no-bitwise */
-const getBitAt = position => byte => (byte >> position) & 1;
-const setBitAt = position => byte => byte | (1 << position);
-const resetBitAt = position => byte => byte & ~(1 << position);
+const getBitAt = (position) => (byte) => (byte >> position) & 1;
+const setBitAt = (position) => (byte) => byte | (1 << position);
+const resetBitAt = (position) => (byte) => byte & ~(1 << position);
 /* eslint-enable no-bitwise */
-const setOrResetBitAt = bit => (bit === 1 ? setBitAt : resetBitAt);
+const setOrResetBitAt = (bit) => (bit === 1 ? setBitAt : resetBitAt);
 
-const getByteAt = position => str => str.charCodeAt(position);
-const setByteAt = byte => position => str =>
+const getByteAt = (position) => (str) => str.charCodeAt(position);
+const setByteAt = (byte) => (position) => (str) =>
   str.substr(0, position) +
   String.fromCharCode(byte) +
   str.substr(position + 1);

--- a/src/commands/sinter.js
+++ b/src/commands/sinter.js
@@ -5,12 +5,12 @@ import { sunion } from './index';
 
 export function sinter(...keys) {
   const values = sunion.apply(this, keys);
-  const sets = keys.map(
-    key => (this.data.has(key) ? this.data.get(key) : new Set())
+  const sets = keys.map((key) =>
+    this.data.has(key) ? this.data.get(key) : new Set()
   );
 
   const intersection = new Set(
-    values.filter(value =>
+    values.filter((value) =>
       sets.reduce(
         (isShared, set) => (set.has(value) ? isShared : false),
         /* isShared */ true

--- a/src/commands/spop.js
+++ b/src/commands/spop.js
@@ -1,7 +1,7 @@
 import _ from 'lodash';
 import Set from 'es6-set';
 
-const safeCount = count => {
+const safeCount = (count) => {
   const result = count !== undefined ? parseInt(count, 10) : 1;
   if (Number.isNaN(result) || result < 0) {
     throw new Error('ERR value is not an integer or out of range');
@@ -30,7 +30,7 @@ export function spop(key, count) {
   } else {
     values.shuffle(); // Randomize take
     result = values.take(want).value();
-    result.map(item => set.delete(item));
+    result.map((item) => set.delete(item));
   }
 
   this.data.set(key, set);

--- a/src/commands/srem.js
+++ b/src/commands/srem.js
@@ -5,7 +5,7 @@ export function srem(key, ...vals) {
 
   let removed = 0;
   const set = this.data.get(key);
-  vals.forEach(val => {
+  vals.forEach((val) => {
     if (set.has(val)) {
       removed++;
     }

--- a/src/commands/sscan.js
+++ b/src/commands/sscan.js
@@ -5,6 +5,6 @@ export function sscan(key, cursor, ...args) {
     return ['0', []];
   }
   const setKeys = [];
-  this.data.get(key).forEach(value => setKeys.push(value));
+  this.data.get(key).forEach((value) => setKeys.push(value));
   return scanHelper(setKeys, 1, cursor, ...args);
 }

--- a/src/commands/subscribe.js
+++ b/src/commands/subscribe.js
@@ -4,7 +4,7 @@ import {
 } from '../commands-utils/channel-subscription';
 
 export function subscribe(...args) {
-  args.forEach(chan => {
+  args.forEach((chan) => {
     if (!this.channels.instanceListeners) {
       this.channels.instanceListeners = new Map();
     }

--- a/src/commands/sunion.js
+++ b/src/commands/sunion.js
@@ -2,14 +2,14 @@ import arrayFrom from 'array-from';
 import Set from 'es6-set';
 
 export function sunion(...keys) {
-  keys.forEach(key => {
+  keys.forEach((key) => {
     if (this.data.has(key) && !(this.data.get(key) instanceof Set)) {
       throw new Error(`Key ${key} does not contain a set`);
     }
   });
 
-  const sets = keys.map(
-    key => (this.data.has(key) ? this.data.get(key) : new Set())
+  const sets = keys.map((key) =>
+    this.data.has(key) ? this.data.get(key) : new Set()
   );
   const union = new Set(
     sets.reduce((combined, set) => [...combined, ...arrayFrom(set)], [])

--- a/src/commands/unsubscribe.js
+++ b/src/commands/unsubscribe.js
@@ -5,14 +5,14 @@ import {
 
 export function unsubscribe(...args) {
   if (args.length === 0) {
-    getSubscribedChannels(this, this.channels).forEach(channel => {
+    getSubscribedChannels(this, this.channels).forEach((channel) => {
       unsubscribeFromChannel(this, channel, this.channels);
     });
 
     return 0;
   }
 
-  args.forEach(chan => {
+  args.forEach((chan) => {
     unsubscribeFromChannel(this, chan, this.channels);
   });
 

--- a/src/commands/xread.js
+++ b/src/commands/xread.js
@@ -53,7 +53,7 @@ export function xread(option, ...args) {
     );
 
   return op === 'BLOCK'
-    ? new Promise(resolve => {
+    ? new Promise((resolve) => {
         let timeElapsed = 0;
         const f = () =>
           setTimeout(() => {
@@ -65,7 +65,7 @@ export function xread(option, ...args) {
           }, 100);
         f();
       })
-    : new Promise(resolve => {
+    : new Promise((resolve) => {
         const events = pollEvents(toPoll, opVal);
         if (events.length === 0) return resolve(null);
         return resolve(events.slice().reverse());

--- a/src/commands/xrevrange.js
+++ b/src/commands/xrevrange.js
@@ -13,10 +13,7 @@ export function xrevrange(stream, end, start, ...args) {
     return [];
   }
 
-  const list = this.data
-    .get(stream)
-    .slice()
-    .reverse();
+  const list = this.data.get(stream).slice().reverse();
   const min = start === '-' ? -Infinity : start;
   const max = end === '+' ? Infinity : end;
 

--- a/src/commands/zinterstore.js
+++ b/src/commands/zinterstore.js
@@ -18,7 +18,7 @@ export function zinterstore(destKey, numKeys, ...keys) {
   }
 
   // deep copy inputs
-  const inputs = srcMaps.map(x =>
+  const inputs = srcMaps.map((x) =>
     JSON.parse(JSON.stringify(arrayFrom(x.values())))
   );
 

--- a/src/commands/zpopmax.js
+++ b/src/commands/zpopmax.js
@@ -14,10 +14,10 @@ export function zpopmax(key, count = 1) {
     slice(orderBy(arrayFrom(map.values()), ['score', 'value']), -count, -1)
   );
 
-  forEach(ordered, it => {
+  forEach(ordered, (it) => {
     map.delete(it.value);
   });
   this.data.set(key, map);
 
-  return flatMap(ordered, it => [it.value, it.score]);
+  return flatMap(ordered, (it) => [it.value, it.score]);
 }

--- a/src/commands/zpopmin.js
+++ b/src/commands/zpopmin.js
@@ -16,10 +16,10 @@ export function zpopmin(key, count = 1) {
     count - 1
   );
 
-  forEach(ordered, it => {
+  forEach(ordered, (it) => {
     map.delete(it.value);
   });
   this.data.set(key, map);
 
-  return flatMap(ordered, it => [it.value, it.score]);
+  return flatMap(ordered, (it) => [it.value, it.score]);
 }

--- a/src/commands/zrange-command.common.js
+++ b/src/commands/zrange-command.common.js
@@ -53,7 +53,7 @@ export function parseLimit(input) {
 }
 
 export function filterPredicate(min, max) {
-  return it => {
+  return (it) => {
     if (it.score < min.value || (min.isStrict && it.score === min.value)) {
       return false;
     }

--- a/src/commands/zrange.js
+++ b/src/commands/zrange.js
@@ -27,8 +27,8 @@ export function zrange(key, s, e, withScores) {
     typeof withScores === 'string' &&
     withScores.toUpperCase() === 'WITHSCORES'
   ) {
-    return flatMap(ordered, it => [it.value, it.score]);
+    return flatMap(ordered, (it) => [it.value, it.score]);
   }
 
-  return ordered.map(it => it.value);
+  return ordered.map((it) => it.value);
 }

--- a/src/commands/zrangebyscore.js
+++ b/src/commands/zrangebyscore.js
@@ -33,10 +33,10 @@ export function zrangebyscore(key, inputMin, inputMax, ...args) {
       ordered = offsetAndLimit(ordered, offset, limit);
     }
 
-    return flatMap(ordered, it => [it.value, it.score]);
+    return flatMap(ordered, (it) => [it.value, it.score]);
   }
 
-  const results = ordered.map(it => it.value);
+  const results = ordered.map((it) => it.value);
   if (limit !== null) {
     return offsetAndLimit(results, offset, limit);
   }

--- a/src/commands/zrem.js
+++ b/src/commands/zrem.js
@@ -3,7 +3,7 @@ export function zrem(key, ...vals) {
   if (!map) return 0;
 
   let removed = 0;
-  vals.forEach(val => {
+  vals.forEach((val) => {
     if (map.delete(val)) {
       removed++;
     }

--- a/src/commands/zremrangebyrank.js
+++ b/src/commands/zremrangebyrank.js
@@ -8,7 +8,7 @@ export function zremrangebyrank(key, s, e) {
   }
 
   const map = this.data.get(key);
-  vals.forEach(val => {
+  vals.forEach((val) => {
     map.delete(val);
   });
 

--- a/src/commands/zremrangebyscore.js
+++ b/src/commands/zremrangebyscore.js
@@ -8,7 +8,7 @@ export function zremrangebyscore(key, inputMin, inputMax) {
   }
 
   const map = this.data.get(key);
-  vals.forEach(val => {
+  vals.forEach((val) => {
     map.delete(val);
   });
   this.data.set(key, map);

--- a/src/commands/zrevrange.js
+++ b/src/commands/zrevrange.js
@@ -21,7 +21,7 @@ export function zrevrange(key, s, e, w) {
     arrayFrom(map.values()),
     ['score', 'value'],
     ['desc', 'desc']
-  ).map(it => {
+  ).map((it) => {
     if (w) {
       return [it.value, it.score];
     }

--- a/src/commands/zrevrangebyscore.js
+++ b/src/commands/zrevrangebyscore.js
@@ -33,10 +33,10 @@ export function zrevrangebyscore(key, inputMax, inputMin, ...args) {
       ordered = offsetAndLimit(ordered, offset, limit);
     }
 
-    return flatMap(ordered, it => [it.value, it.score]);
+    return flatMap(ordered, (it) => [it.value, it.score]);
   }
 
-  const results = ordered.map(it => it.value);
+  const results = ordered.map((it) => it.value);
   if (limit !== null) {
     return offsetAndLimit(results, offset, limit);
   }

--- a/src/data.js
+++ b/src/data.js
@@ -90,7 +90,7 @@ export default function createData(
 
   const data = createInstance(keyPrefix, expiresInstance);
 
-  Object.keys(initial).forEach(key => data.set(key, initial[key]));
+  Object.keys(initial).forEach((key) => data.set(key, initial[key]));
 
   return data;
 }

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,14 @@ const defaultOptions = {
 };
 
 class RedisMock extends EventEmitter {
+  static get Promise() {
+    return promiseContainer.get();
+  }
+
+  static set Promise(lib) {
+    return promiseContainer.set(lib);
+  }
+
   constructor(options = {}) {
     super();
     this.channels = new EventEmitter();
@@ -124,10 +132,5 @@ RedisMock.prototype.Command = {
     RedisMock.prototype.Command.transformers.reply[name] = func;
   },
 };
-
-Object.defineProperty(RedisMock, 'Promise', {
-  get: () => promiseContainer.get(),
-  set: (lib) => promiseContainer.set(lib),
-});
 
 module.exports = RedisMock;

--- a/src/index.js
+++ b/src/index.js
@@ -99,7 +99,7 @@ class RedisMock extends EventEmitter {
   }
 
   _initCommands() {
-    Object.keys(commands).forEach(command => {
+    Object.keys(commands).forEach((command) => {
       const commandName = command === 'evaluate' ? 'eval' : command;
       this[commandName] = createCommand(
         commands[command].bind(this),
@@ -108,7 +108,7 @@ class RedisMock extends EventEmitter {
       );
     });
 
-    Object.keys(commandsStream).forEach(command => {
+    Object.keys(commandsStream).forEach((command) => {
       this[command] = commandsStream[command].bind(this);
     });
   }
@@ -127,7 +127,7 @@ RedisMock.prototype.Command = {
 
 Object.defineProperty(RedisMock, 'Promise', {
   get: () => promiseContainer.get(),
-  set: lib => promiseContainer.set(lib),
+  set: (lib) => promiseContainer.set(lib),
 });
 
 module.exports = RedisMock;

--- a/src/lua.js
+++ b/src/lua.js
@@ -9,7 +9,7 @@ const {
   to_jsstring: toJsString,
 } = fengari;
 
-const luaExecString = L => str => {
+const luaExecString = (L) => (str) => {
   const retCode = lauxlib.luaL_dostring(L, toLuaString(str));
   if (retCode !== 0) {
     const errorMsg = lua.lua_tojsstring(L, -1);
@@ -35,7 +35,7 @@ const luaExecString = L => str => {
 //   console.log(output.join('\n'))
 // };
 
-const getTopLength = L => {
+const getTopLength = (L) => {
   // get length of array in top of the stack
   lua.lua_len(L, -1);
   const length = lua.lua_tointeger(L, -1);
@@ -44,10 +44,10 @@ const getTopLength = L => {
   // ~get length of array in top of the stack
 };
 
-const typeOf = L => pos =>
+const typeOf = (L) => (pos) =>
   toJsString(lua.lua_typename(L, lua.lua_type(L, pos)));
 
-const getTopKeys = L => {
+const getTopKeys = (L) => {
   if (lua.lua_isnil(L, -1)) throw new Error('cannot get keys on nil');
   if (!lua.lua_istable(L, -1))
     throw new Error(`non-tables don't have keys! type is "${typeOf(L)(-1)}"`);
@@ -60,7 +60,7 @@ const getTopKeys = L => {
   return keys;
 };
 
-const isTopArray = L => () => {
+const isTopArray = (L) => () => {
   try {
     const keys = getTopKeys(L);
     // reversing as putting and getting things from the stack ends with everything upside down.
@@ -70,7 +70,7 @@ const isTopArray = L => () => {
   }
 };
 
-const makeReturnValue = L => {
+const makeReturnValue = (L) => {
   const isArray = isTopArray(L)();
   if (!isArray) {
     return interop.tojs(L, -1);
@@ -95,7 +95,7 @@ const makeReturnValue = L => {
   return retVal;
 };
 
-const popReturnValue = L => topBeforeCall => {
+const popReturnValue = (L) => (topBeforeCall) => {
   const numReturn = lua.lua_gettop(L) - topBeforeCall + 1;
   let ret;
   if (numReturn > 0) {
@@ -105,11 +105,11 @@ const popReturnValue = L => topBeforeCall => {
   return ret;
 };
 
-const pushTable = L => obj => {
+const pushTable = (L) => (obj) => {
   lua.lua_newtable(L);
   const index = lua.lua_gettop(L);
 
-  Object.keys(obj).forEach(fieldName => {
+  Object.keys(obj).forEach((fieldName) => {
     interop.push(L, fieldName);
     // eslint-disable-next-line no-use-before-define
     push(L)(obj[fieldName]);
@@ -117,7 +117,7 @@ const pushTable = L => obj => {
   });
 };
 
-const pushArray = L => array => {
+const pushArray = (L) => (array) => {
   lua.lua_newtable(L);
   const subTableIndex = lua.lua_gettop(L);
 
@@ -128,7 +128,7 @@ const pushArray = L => array => {
   });
 };
 
-const push = L => value => {
+const push = (L) => (value) => {
   if (Array.isArray(value)) {
     pushArray(L)(value);
   } else if (value && typeof value === 'object' && !Array.isArray(value)) {
@@ -138,18 +138,18 @@ const push = L => value => {
   }
 };
 
-const defineGlobalArray = L => (array, name) => {
+const defineGlobalArray = (L) => (array, name) => {
   push(L)(array);
   lua.lua_setglobal(L, toLuaString(name));
 };
 
-const defineGlobalFunction = L => (fn, name) => {
+const defineGlobalFunction = (L) => (fn, name) => {
   // define global fn call
   lua.lua_pushjsfunction(L, fn);
   lua.lua_setglobal(L, toLuaString(name));
 };
 
-const extractArgs = L => () => {
+const extractArgs = (L) => () => {
   const top = lua.lua_gettop(L);
   const args = [];
   let a = -top;
@@ -157,7 +157,7 @@ const extractArgs = L => () => {
     args.push(a);
     a += 1;
   }
-  return args.map(i => interop.tojs(L, i));
+  return args.map((i) => interop.tojs(L, i));
 };
 
 export const init = () => {
@@ -179,7 +179,7 @@ export const init = () => {
   };
 };
 
-export const dispose = vm => {
+export const dispose = (vm) => {
   const L = vm.L || vm;
   lua.lua_close(L);
 };

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -9,7 +9,7 @@ class Pipeline {
     this.redis = redis;
     this._transactions = 0;
 
-    Object.keys(commands).forEach(command => {
+    Object.keys(commands).forEach((command) => {
       this[command] = this._createCommand(command);
     });
   }
@@ -36,7 +36,7 @@ class Pipeline {
     const Promise = promiseContainer.get();
     this.batch.push(() =>
       asCallback(
-        new Promise(resolve =>
+        new Promise((resolve) =>
           resolve(
             safelyExecuteCommand(
               commandEmulator,
@@ -59,8 +59,8 @@ class Pipeline {
 
     this.batch = [];
     return asCallback(
-      Promise.all(batch.map(cmd => cmd())).then(replies =>
-        replies.map(reply => [null, reply])
+      Promise.all(batch.map((cmd) => cmd())).then((replies) =>
+        replies.map((reply) => [null, reply])
       ),
       callback
     );

--- a/src/promise-container.js
+++ b/src/promise-container.js
@@ -2,7 +2,7 @@ let promise = global.Promise;
 
 const promiseContainer = {
   get: () => promise,
-  set: lib => {
+  set: (lib) => {
     if (typeof lib !== 'function') {
       throw new Error(`Provided Promise must be a function, got ${lib}`);
     }

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,8 +3,11 @@
     "mocha": true
   },
   "rules": {
-    "import/no-extraneous-dependencies": ['error', {
-      "devDependencies": true
-    }]
+    "import/no-extraneous-dependencies": [
+      "error",
+      {
+        "devDependencies": true
+      }
+    ]
   }
 }

--- a/test/command.js
+++ b/test/command.js
@@ -8,7 +8,7 @@ describe('basic command', () => {
     Command: { transformers: { argument: {}, reply: {} } },
   });
   it('should return a Promise that resolves the returned value', () =>
-    stub('OK').then(reply => expect(reply).toEqual(['OK'])));
+    stub('OK').then((reply) => expect(reply).toEqual(['OK'])));
 
   it('should support node style callbacks', () => {
     const spy = createSpy();
@@ -17,14 +17,14 @@ describe('basic command', () => {
 
   it('should convert non-buffer arguments to strings', () => {
     const args = [createBuffer('foo'), 'bar', 1, null, undefined];
-    return stub(...args).then(reply =>
+    return stub(...args).then((reply) =>
       expect(reply).toEqual([createBuffer('foo'), 'bar', '1', '', ''])
     );
   });
 
   it('should flatten args', () => {
     const args = [['foo', 'bar', 'baz']];
-    return stub(...args).then(reply =>
+    return stub(...args).then((reply) =>
       expect(reply).toEqual(['foo', 'bar', 'baz'])
     );
   });

--- a/test/commands/append.js
+++ b/test/commands/append.js
@@ -12,7 +12,7 @@ describe('append', () => {
 
     return redis
       .append('mykey', ' World')
-      .then(newLength => expect(newLength).toBe(11))
+      .then((newLength) => expect(newLength).toBe(11))
       .then(() => expect(redis.data.get('mykey')).toBe('Hello World'));
   });
   it('should set empty string if key does not exist', () => {
@@ -20,7 +20,7 @@ describe('append', () => {
 
     return redis
       .append('mykey', ' World')
-      .then(newLength => expect(newLength).toBe(6))
+      .then((newLength) => expect(newLength).toBe(6))
       .then(() => expect(redis.data.get('mykey')).toBe(' World'));
   });
 });

--- a/test/commands/auth.js
+++ b/test/commands/auth.js
@@ -6,6 +6,6 @@ describe('auth', () => {
   it('should return OK', () => {
     const redis = new MockRedis();
 
-    return redis.auth('123456').then(status => expect(status).toBe('OK'));
+    return redis.auth('123456').then((status) => expect(status).toBe('OK'));
   });
 });

--- a/test/commands/bgrewriteaof.js
+++ b/test/commands/bgrewriteaof.js
@@ -6,6 +6,6 @@ describe('bgrewriteaof', () => {
   it('should return OK', () => {
     const redis = new MockRedis();
 
-    return redis.bgrewriteaof().then(status => expect(status).toBe('OK'));
+    return redis.bgrewriteaof().then((status) => expect(status).toBe('OK'));
   });
 });

--- a/test/commands/bgsave.js
+++ b/test/commands/bgsave.js
@@ -6,6 +6,6 @@ describe('bgsave', () => {
   it('should return OK', () => {
     const redis = new MockRedis();
 
-    return redis.bgsave().then(status => expect(status).toBe('OK'));
+    return redis.bgsave().then((status) => expect(status).toBe('OK'));
   });
 });

--- a/test/commands/brpoplpush.js
+++ b/test/commands/brpoplpush.js
@@ -35,7 +35,7 @@ describe('brpoplpush', () => {
 
     return redis
       .brpoplpush('foo', 'bar')
-      .then(item => expect(item).toEqual(null));
+      .then((item) => expect(item).toEqual(null));
   });
 
   it('should return null if the source list is empty', () => {
@@ -47,7 +47,7 @@ describe('brpoplpush', () => {
 
     return redis
       .brpoplpush('foo', 'bar')
-      .then(item => expect(item).toEqual(null));
+      .then((item) => expect(item).toEqual(null));
   });
 
   it('should return the item', () => {
@@ -59,7 +59,7 @@ describe('brpoplpush', () => {
 
     return redis
       .brpoplpush('foo', 'bar')
-      .then(item => expect(item).toBe('bar'));
+      .then((item) => expect(item).toBe('bar'));
   });
 
   it('should throw an exception if the source key contains something other than a list', () => {
@@ -72,7 +72,7 @@ describe('brpoplpush', () => {
 
     return redis
       .brpoplpush('foo', 'bar')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });
@@ -87,7 +87,7 @@ describe('brpoplpush', () => {
 
     return redis
       .brpoplpush('foo', 'bar')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key bar does not contain a list')
       );
   });

--- a/test/commands/brpoplpushBuffer.js
+++ b/test/commands/brpoplpushBuffer.js
@@ -36,7 +36,7 @@ describe('brpoplpushBuffer', () => {
 
     return redis
       .brpoplpushBuffer('foo', 'bar')
-      .then(item => expect(item).toEqual(null));
+      .then((item) => expect(item).toEqual(null));
   });
 
   it('should return null if the source list is empty', () => {
@@ -48,7 +48,7 @@ describe('brpoplpushBuffer', () => {
 
     return redis
       .brpoplpushBuffer('foo', 'bar')
-      .then(item => expect(item).toEqual(null));
+      .then((item) => expect(item).toEqual(null));
   });
 
   it('should return the item as buffer', () => {
@@ -58,7 +58,7 @@ describe('brpoplpushBuffer', () => {
       },
     });
 
-    return redis.brpoplpushBuffer('foo', 'bar').then(item => {
+    return redis.brpoplpushBuffer('foo', 'bar').then((item) => {
       expect(Buffer.isBuffer(item)).toBeTruthy();
       expect(item).toEqual(Buffer.from('bar'));
     });
@@ -74,7 +74,7 @@ describe('brpoplpushBuffer', () => {
 
     return redis
       .brpoplpushBuffer('foo', bufferVal)
-      .then(item => expect(item).toEqual(bufferVal));
+      .then((item) => expect(item).toEqual(bufferVal));
   });
 
   it('should throw an exception if the source key contains something other than a list', () => {
@@ -87,7 +87,7 @@ describe('brpoplpushBuffer', () => {
 
     return redis
       .brpoplpushBuffer('foo', 'bar')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });
@@ -102,7 +102,7 @@ describe('brpoplpushBuffer', () => {
 
     return redis
       .brpoplpushBuffer('foo', 'bar')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key bar does not contain a list')
       );
   });

--- a/test/commands/connect.js
+++ b/test/commands/connect.js
@@ -3,7 +3,7 @@ import expect from 'expect';
 import MockRedis from '../../src';
 
 describe('connect', () => {
-  it('should throw if redis has already connected in ctor', done => {
+  it('should throw if redis has already connected in ctor', (done) => {
     // no option specified means {lazyConnect: false}
     const redis = new MockRedis();
 
@@ -13,21 +13,21 @@ describe('connect', () => {
         .then(() => {
           throw new Error('connect should not have succeeded');
         })
-        .catch(reason => {
+        .catch((reason) => {
           expect(reason.message).toBe('Redis is already connecting/connected');
           done();
         });
     }, 20);
   });
 
-  it('should signal successful connection', done => {
+  it('should signal successful connection', (done) => {
     const redis = new MockRedis({ lazyConnect: true });
 
     setTimeout(() => {
       redis
         .connect()
-        .catch(reason => expect(reason).toNotExist())
-        .then(result => {
+        .catch((reason) => expect(reason).toNotExist())
+        .then((result) => {
           expect(result).toBe(undefined);
           done();
         });
@@ -39,13 +39,13 @@ describe('connect', () => {
 
     return redis
       .connect()
-      .then(result => expect(result).toBe(undefined))
+      .then((result) => expect(result).toBe(undefined))
       .then(
         () =>
-          new Promise(resolve => {
+          new Promise((resolve) => {
             redis
               .connect()
-              .catch(reason => expect(reason).toBeA(Error))
+              .catch((reason) => expect(reason).toBeA(Error))
               .then(() => resolve());
           })
       );
@@ -59,7 +59,7 @@ describe('connect', () => {
       .then(() => {
         throw new Error('get shall not succeed when redis is not connected');
       })
-      .catch(reason =>
+      .catch((reason) =>
         expect(reason.message).toBe(
           "Stream isn't writeable and enableOfflineQueue options is false"
         )

--- a/test/commands/dbsize.js
+++ b/test/commands/dbsize.js
@@ -11,6 +11,6 @@ describe('dbsize', () => {
       },
     });
 
-    return redis.dbsize().then(result => expect(result).toBe(2));
+    return redis.dbsize().then((result) => expect(result).toBe(2));
   });
 });

--- a/test/commands/decr.js
+++ b/test/commands/decr.js
@@ -12,7 +12,7 @@ describe('decr', () => {
 
     return redis
       .decr('user_next')
-      .then(userNext => expect(userNext).toBe(1))
+      .then((userNext) => expect(userNext).toBe(1))
       .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
 });

--- a/test/commands/decrby.js
+++ b/test/commands/decrby.js
@@ -12,7 +12,7 @@ describe('decrby', () => {
 
     return redis
       .decrby('user_next', 10)
-      .then(userNext => expect(userNext).toBe(1))
+      .then((userNext) => expect(userNext).toBe(1))
       .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
   it('should not increment if no increment is passed', () => {
@@ -24,7 +24,7 @@ describe('decrby', () => {
 
     return redis
       .decrby('user_next')
-      .then(userNext => expect(userNext).toBe(1))
+      .then((userNext) => expect(userNext).toBe(1))
       .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
 });

--- a/test/commands/defineCommand.js
+++ b/test/commands/defineCommand.js
@@ -28,13 +28,13 @@ describe('defineCommand', () => {
       const definition = { numberOfKeys: 1, lua: luaCode };
       return redis
         .set(someKey, initialValue)
-        .then(status => expect(status).toBe('OK'))
+        .then((status) => expect(status).toBe('OK'))
         .then(() => {
           redis.defineCommand('inc2', definition);
         })
         .then(() => redis.inc2(someKey, 5))
         .then(() => redis.get('k'))
-        .then(newValue => expect(newValue).toBe(6));
+        .then((newValue) => expect(newValue).toBe(6));
     });
   });
 
@@ -43,7 +43,7 @@ describe('defineCommand', () => {
     const redis = new MockRedis();
     const definition = { numberOfKeys: 0, lua: luaCode };
     redis.defineCommand('someCmd', definition);
-    return redis.someCmd().then(val => expect(val).toEqual([10, 100, 200]));
+    return redis.someCmd().then((val) => expect(val).toEqual([10, 100, 200]));
   });
 
   it('should support custom commmands returning a table/array of table/array elements', () => {
@@ -53,6 +53,6 @@ describe('defineCommand', () => {
     redis.defineCommand('someCmd', definition);
     return redis
       .someCmd()
-      .then(val => expect(val).toEqual([[10], [100, 200], []]));
+      .then((val) => expect(val).toEqual([[10], [100, 200], []]));
   });
 });

--- a/test/commands/del.js
+++ b/test/commands/del.js
@@ -12,9 +12,9 @@ describe('del', () => {
   it('should delete passed in keys', () =>
     redis
       .del('deleteme', 'metoo')
-      .then(status => expect(status).toBe(2))
+      .then((status) => expect(status).toBe(2))
       .then(() => expect(redis.data.has('deleteme')).toBe(false))
       .then(() => expect(redis.data.has('metoo')).toBe(false)));
   it('return the number of keys removed', () =>
-    redis.del('deleteme', 'metoo').then(status => expect(status).toBe(0)));
+    redis.del('deleteme', 'metoo').then((status) => expect(status).toBe(0)));
 });

--- a/test/commands/discard.js
+++ b/test/commands/discard.js
@@ -6,8 +6,11 @@ describe('discard', () => {
   it('should discard any batch queue ', () => {
     const redis = new MockRedis();
 
-    redis.multi([['incr', 'user_next'], ['incr', 'post_next']]);
-    return redis.discard().then(result => {
+    redis.multi([
+      ['incr', 'user_next'],
+      ['incr', 'post_next'],
+    ]);
+    return redis.discard().then((result) => {
       expect(result).toBe('OK');
       expect(redis.batch).toBe(undefined);
     });
@@ -16,7 +19,7 @@ describe('discard', () => {
   it('errors if you discard without starting a pipeline', () => {
     const redis = new MockRedis();
 
-    return redis.discard().catch(err => {
+    return redis.discard().catch((err) => {
       expect(err).toBeA(Error);
     });
   });

--- a/test/commands/echo.js
+++ b/test/commands/echo.js
@@ -8,6 +8,6 @@ describe('echo', () => {
 
     return redis
       .echo('Hello World!')
-      .then(result => expect(result).toBe('Hello World!'));
+      .then((result) => expect(result).toBe('Hello World!'));
   });
 });

--- a/test/commands/eval.js
+++ b/test/commands/eval.js
@@ -23,7 +23,7 @@ describe('eval', () => {
 
         return redis
           .eval(luaScript, NUMBER_OF_KEYS, KEY1, KEY2, 100, 5)
-          .then(result => expect(result).toEqual(3005));
+          .then((result) => expect(result).toEqual(3005));
       });
   });
 
@@ -41,7 +41,7 @@ describe('eval', () => {
 
       return redis
         .eval(luaScript, NUMBER_OF_KEYS, KEY1)
-        .then(result => expect(result).toEqual(10));
+        .then((result) => expect(result).toEqual(10));
     });
   });
 });

--- a/test/commands/exists.js
+++ b/test/commands/exists.js
@@ -10,5 +10,5 @@ describe('exists', () => {
     },
   });
   it('should return how many keys exists', () =>
-    redis.exists('foo', 'bar', 'baz').then(status => expect(status).toBe(2)));
+    redis.exists('foo', 'bar', 'baz').then((status) => expect(status).toBe(2)));
 });

--- a/test/commands/expire.js
+++ b/test/commands/expire.js
@@ -35,7 +35,7 @@ describe('expire', () => {
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
-    return redis.expire('foo', 1).then(status => expect(status).toBe(0));
+    return redis.expire('foo', 1).then((status) => expect(status).toBe(0));
   });
 
   it('should remove expire on SET', () => {
@@ -74,7 +74,7 @@ describe('expire', () => {
       .then(() => expect(redis.expires.has('baz')).toBe(true));
   });
 
-  it('should emit keyspace notification if configured', done => {
+  it('should emit keyspace notification if configured', (done) => {
     const redis = new MockRedis({ notifyKeyspaceEvents: 'gK' }); // gK: generic Keyspace
     const redisPubSub = redis.createConnectedClient();
     redisPubSub.on('message', (channel, message) => {

--- a/test/commands/expireat.js
+++ b/test/commands/expireat.js
@@ -12,18 +12,18 @@ describe('expireat', () => {
     const at = Math.ceil(Date.now() / 1000) + 1;
     return redis
       .expireat('foo', at)
-      .then(status => {
+      .then((status) => {
         expect(status).toBe(1);
         expect(redis.expires.has('foo')).toBe(true);
 
         return redis.ttl('foo');
       })
-      .then(result => expect(result).toBeGreaterThanOrEqualTo(1));
+      .then((result) => expect(result).toBeGreaterThanOrEqualTo(1));
   });
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
     const at = Math.ceil(Date.now() / 1000);
-    return redis.expireat('foo', at).then(status => expect(status).toBe(0));
+    return redis.expireat('foo', at).then((status) => expect(status).toBe(0));
   });
 });

--- a/test/commands/flushall.js
+++ b/test/commands/flushall.js
@@ -12,7 +12,7 @@ describe('flushall', () => {
   it('should empty current db', () =>
     redis
       .flushall()
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => expect(redis.data.keys().length).toBe(0)));
   it('should empty every db');
 });

--- a/test/commands/flushdb.js
+++ b/test/commands/flushdb.js
@@ -12,7 +12,7 @@ describe('flushdb', () => {
   it('should empty current db', () =>
     redis
       .flushdb()
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => expect(redis.data.keys().length).toBe(0)));
   it('should empty other db after SELECT');
 });

--- a/test/commands/get.js
+++ b/test/commands/get.js
@@ -6,7 +6,7 @@ describe('get', () => {
   it('should return null on keys that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.get('foo').then(result => expect(result).toBe(null));
+    return redis.get('foo').then((result) => expect(result).toBe(null));
   });
 
   it('should return value of key', () => {
@@ -16,6 +16,6 @@ describe('get', () => {
       },
     });
 
-    return redis.get('foo').then(result => expect(result).toBe('bar'));
+    return redis.get('foo').then((result) => expect(result).toBe('bar'));
   });
 });

--- a/test/commands/getBuffer.js
+++ b/test/commands/getBuffer.js
@@ -7,7 +7,7 @@ describe('getBuffer', () => {
   it('should return null on keys that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.getBuffer('foo').then(result => expect(result).toBe(null));
+    return redis.getBuffer('foo').then((result) => expect(result).toBe(null));
   });
 
   it('should return value of key as buffer', () => {
@@ -17,7 +17,7 @@ describe('getBuffer', () => {
       },
     });
 
-    return redis.getBuffer('foo').then(result => {
+    return redis.getBuffer('foo').then((result) => {
       expect(Buffer.isBuffer(result)).toBeTruthy();
       expect(result).toEqual(Buffer.from('bar'));
     });
@@ -33,6 +33,6 @@ describe('getBuffer', () => {
 
     return redis
       .getBuffer('foo')
-      .then(result => expect(result.equals(bufferVal)).toBe(true));
+      .then((result) => expect(result.equals(bufferVal)).toBe(true));
   });
 });

--- a/test/commands/getbit.js
+++ b/test/commands/getbit.js
@@ -6,7 +6,7 @@ describe('getbit', () => {
   it('should return 0 on keys that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.getbit('foo', 0).then(result => expect(result).toBe(0));
+    return redis.getbit('foo', 0).then((result) => expect(result).toBe(0));
   });
 
   it('should throw if offset > 2^32', () => {
@@ -16,7 +16,7 @@ describe('getbit', () => {
       () => {
         throw new Error('Expected getbit to fail');
       },
-      err => {
+      (err) => {
         expect(err).toBeA(Error);
         expect(err.message).toBe(
           'ERR bit offset is not an integer or out of range'
@@ -32,7 +32,7 @@ describe('getbit', () => {
       },
     });
 
-    return redis.getbit('foo', 10).then(result => expect(result).toBe(1));
+    return redis.getbit('foo', 10).then((result) => expect(result).toBe(1));
   });
 
   it('should return 0 if offset is out of range', () => {
@@ -44,6 +44,6 @@ describe('getbit', () => {
 
     return redis
       .getbit('foo', 2 ** 32 - 1)
-      .then(result => expect(result).toBe(0));
+      .then((result) => expect(result).toBe(0));
   });
 });

--- a/test/commands/getrange.js
+++ b/test/commands/getrange.js
@@ -10,18 +10,18 @@ describe('getrange', () => {
   });
 
   it('should return "This"', () =>
-    redis.getrange('foo', 0, 3).then(result => expect(result).toBe('This')));
+    redis.getrange('foo', 0, 3).then((result) => expect(result).toBe('This')));
 
   it('should return "ing"', () =>
-    redis.getrange('foo', -3, -1).then(result => expect(result).toBe('ing')));
+    redis.getrange('foo', -3, -1).then((result) => expect(result).toBe('ing')));
 
   it('should return "This is a string"', () =>
     redis
       .getrange('foo', 0, -1)
-      .then(result => expect(result).toBe('This is a string')));
+      .then((result) => expect(result).toBe('This is a string')));
 
   it('should return "string"', () =>
     redis
       .getrange('foo', 10, 100)
-      .then(result => expect(result).toBe('string')));
+      .then((result) => expect(result).toBe('string')));
 });

--- a/test/commands/hdel.js
+++ b/test/commands/hdel.js
@@ -15,20 +15,20 @@ describe('hdel', () => {
   it('should delete passed in keys from hash map, and when the last key is removed, should remove the hash map itself', () =>
     redis
       .hdel('user:1', 'id', 'email', 'location')
-      .then(status => expect(status).toBe(2))
+      .then((status) => expect(status).toBe(2))
       .then(() =>
         expect(redis.data.get('user:1')).toEqual({ name: 'Bruce Wayne' })
       )
       .then(() => redis.hdel('user:1', 'name'))
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => redis.exists('user:1'))
-      .then(status => expect(status).toBe(0)));
+      .then((status) => expect(status).toBe(0)));
 
-  it('should return 0 for key that does not exist', done => {
+  it('should return 0 for key that does not exist', (done) => {
     redis
       .hdel('nonExistingUser', 'someField')
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() => done())
-      .catch(err => done(err));
+      .catch((err) => done(err));
   });
 });

--- a/test/commands/hexists.js
+++ b/test/commands/hexists.js
@@ -11,16 +11,16 @@ describe('hexists', () => {
     });
 
     it('should return 1 if key exists in hash map', () =>
-      redis.hexists('foo', 'bar').then(status => expect(status).toBe(1)));
+      redis.hexists('foo', 'bar').then((status) => expect(status).toBe(1)));
 
     it('should return 0 if key not exists in hash map', () =>
-      redis.hexists('foo', 'baz').then(status => expect(status).toBe(0)));
+      redis.hexists('foo', 'baz').then((status) => expect(status).toBe(0)));
   });
 
   context("hash doesn't exist", () => {
     const redis = new MockRedis();
 
     it('should return 0', () =>
-      redis.hexists('foo', 'baz').then(status => expect(status).toBe(0)));
+      redis.hexists('foo', 'baz').then((status) => expect(status).toBe(0)));
   });
 });

--- a/test/commands/hget.js
+++ b/test/commands/hget.js
@@ -14,14 +14,14 @@ describe('hget', () => {
 
     return redis
       .hget('emails', 'clark@daily.planet')
-      .then(userId => expect(userId).toBe('1'));
+      .then((userId) => expect(userId).toBe('1'));
   });
 
   it('should return null if the hash does not exist', () => {
     const redis = new MockRedis();
     return redis
       .hget('emails', 'clark@daily.planet')
-      .then(userId => expect(userId).toBe(null));
+      .then((userId) => expect(userId).toBe(null));
   });
 
   it('should return null if the item does not exist in the hash', () => {
@@ -35,6 +35,6 @@ describe('hget', () => {
 
     return redis
       .hget('emails', 'lois@daily.planet')
-      .then(userId => expect(userId).toBe(null));
+      .then((userId) => expect(userId).toBe(null));
   });
 });

--- a/test/commands/hgetBuffer.js
+++ b/test/commands/hgetBuffer.js
@@ -13,7 +13,7 @@ describe('hgetBuffer', () => {
       },
     });
 
-    return redis.hgetBuffer('emails', 'clark@daily.planet').then(userId => {
+    return redis.hgetBuffer('emails', 'clark@daily.planet').then((userId) => {
       expect(Buffer.isBuffer(userId)).toBeTruthy();
       expect(userId).toEqual(createBuffer('1'));
     });
@@ -23,7 +23,7 @@ describe('hgetBuffer', () => {
     const redis = new MockRedis();
     return redis
       .hgetBuffer('emails', 'clark@daily.planet')
-      .then(userId => expect(userId).toBe(null));
+      .then((userId) => expect(userId).toBe(null));
   });
 
   it('should return null if the item does not exist in the hash', () => {
@@ -37,6 +37,6 @@ describe('hgetBuffer', () => {
 
     return redis
       .hgetBuffer('emails', 'lois@daily.planet')
-      .then(userId => expect(userId).toBe(null));
+      .then((userId) => expect(userId).toBe(null));
   });
 });

--- a/test/commands/hgetall.js
+++ b/test/commands/hgetall.js
@@ -16,11 +16,11 @@ describe('hgetall', () => {
 
     return redis
       .hgetall('emails')
-      .then(result => expect(result).toEqual(emails));
+      .then((result) => expect(result).toEqual(emails));
   });
 
   it('should return an empty object if the hash does not exist', () => {
     const redis = new MockRedis();
-    return redis.hgetall('emails').then(result => expect(result).toEqual({}));
+    return redis.hgetall('emails').then((result) => expect(result).toEqual({}));
   });
 });

--- a/test/commands/hgetallBuffer.js
+++ b/test/commands/hgetallBuffer.js
@@ -19,8 +19,8 @@ describe('hgetallBuffer', () => {
       },
     });
 
-    return redis.hgetallBuffer('emails').then(result => {
-      Object.keys(result).forEach(key => {
+    return redis.hgetallBuffer('emails').then((result) => {
+      Object.keys(result).forEach((key) => {
         expect(Buffer.isBuffer(result[key])).toBeTruthy();
       });
       expect(result).toEqual(expected);
@@ -31,6 +31,6 @@ describe('hgetallBuffer', () => {
     const redis = new MockRedis();
     return redis
       .hgetallBuffer('emails')
-      .then(result => expect(result).toEqual({}));
+      .then((result) => expect(result).toEqual({}));
   });
 });

--- a/test/commands/hincrby.js
+++ b/test/commands/hincrby.js
@@ -14,7 +14,7 @@ describe('hincrby', () => {
 
     return redis
       .hincrby('highscores', 'user:1', 100)
-      .then(result => expect(result).toBe(9100))
+      .then((result) => expect(result).toBe(9100))
       .then(() => expect(redis.data.get('highscores')['user:1']).toBe('9100'));
   });
   it('should create hash if not exists', () => {
@@ -22,7 +22,7 @@ describe('hincrby', () => {
 
     return redis
       .hincrby('stats', 'hits', 100)
-      .then(result => expect(result).toBe(100))
+      .then((result) => expect(result).toBe(100))
       .then(() => expect(redis.data.get('stats').hits).toBe('100'));
   });
   it('should create field in hash if not exists', () => {
@@ -34,7 +34,7 @@ describe('hincrby', () => {
 
     return redis
       .hincrby('stats', 'hits', 100)
-      .then(result => expect(result).toBe(100))
+      .then((result) => expect(result).toBe(100))
       .then(() => expect(redis.data.get('stats').hits).toBe('100'));
   });
   it('should decrement value in hash if negative integer is passed', () => {
@@ -48,7 +48,7 @@ describe('hincrby', () => {
 
     return redis
       .hincrby('highscores', 'user:1', -100)
-      .then(result => expect(result).toBe(8900))
+      .then((result) => expect(result).toBe(8900))
       .then(() => expect(redis.data.get('highscores')['user:1']).toBe('8900'));
   });
 });

--- a/test/commands/hincrbyfloat.js
+++ b/test/commands/hincrbyfloat.js
@@ -12,9 +12,9 @@ describe('hincrbyfloat', () => {
 
     return redis
       .hincrbyfloat('mykey', 'field', 0.1)
-      .then(result => expect(result).toBe('10.6'))
+      .then((result) => expect(result).toBe('10.6'))
       .then(() => redis.hincrbyfloat('mykey', 'field', -5))
-      .then(result => expect(result).toBe('5.6'))
+      .then((result) => expect(result).toBe('5.6'))
       .then(() => expect(redis.data.get('mykey').field).toBe('5.6'));
   });
 
@@ -27,7 +27,7 @@ describe('hincrbyfloat', () => {
 
     return redis
       .hincrbyfloat('mykey', 'field', '2.0e2')
-      .then(result => expect(result).toBe('5200'))
+      .then((result) => expect(result).toBe('5200'))
       .then(() => expect(redis.data.get('mykey').field).toBe('5200'));
   });
 
@@ -36,7 +36,7 @@ describe('hincrbyfloat', () => {
 
     return redis
       .hincrbyfloat('stats', 'health', 0.5)
-      .then(result => expect(result).toBe('0.5'))
+      .then((result) => expect(result).toBe('0.5'))
       .then(() => expect(redis.data.get('stats').health).toBe('0.5'));
   });
 
@@ -49,7 +49,7 @@ describe('hincrbyfloat', () => {
 
     return redis
       .hincrbyfloat('stats', 'health', 0.5)
-      .then(result => expect(result).toBe('0.5'))
+      .then((result) => expect(result).toBe('0.5'))
       .then(() => expect(redis.data.get('stats').health).toBe('0.5'));
   });
 });

--- a/test/commands/hkeys.js
+++ b/test/commands/hkeys.js
@@ -6,7 +6,7 @@ describe('hkeys', () => {
   it('should return an empty array if there are no keys', () => {
     const redis = new MockRedis();
 
-    return redis.hkeys('foo').then(result => expect(result).toEqual([]));
+    return redis.hkeys('foo').then((result) => expect(result).toEqual([]));
   });
 
   it('should return all data keys', () => {
@@ -18,6 +18,6 @@ describe('hkeys', () => {
 
     return redis
       .hkeys('foo')
-      .then(result => expect(result).toEqual(['bar', 'baz']));
+      .then((result) => expect(result).toEqual(['bar', 'baz']));
   });
 });

--- a/test/commands/hlen.js
+++ b/test/commands/hlen.js
@@ -6,7 +6,7 @@ describe('hlen', () => {
   it('should return an empty array if there are no keys', () => {
     const redis = new MockRedis();
 
-    return redis.hlen('foo').then(result => expect(result).toBe(0));
+    return redis.hlen('foo').then((result) => expect(result).toBe(0));
   });
 
   it('should return all data keys', () => {
@@ -16,6 +16,6 @@ describe('hlen', () => {
       },
     });
 
-    return redis.hlen('foo').then(result => expect(result).toEqual(2));
+    return redis.hlen('foo').then((result) => expect(result).toEqual(2));
   });
 });

--- a/test/commands/hmget.js
+++ b/test/commands/hmget.js
@@ -11,7 +11,7 @@ describe('hmget', () => {
     });
     return redis
       .hmget('user:1', 'id', 'email', 'location')
-      .then(values =>
+      .then((values) =>
         expect(values).toEqual(['1', 'bruce@wayne.enterprises', null])
       );
   });
@@ -20,6 +20,6 @@ describe('hmget', () => {
     const redis = new MockRedis();
     return redis
       .hmget('user:1', 'id', 'email', 'location')
-      .then(values => expect(values).toEqual([null, null, null]));
+      .then((values) => expect(values).toEqual([null, null, null]));
   });
 });

--- a/test/commands/hmgetBuffer.js
+++ b/test/commands/hmgetBuffer.js
@@ -12,7 +12,7 @@ describe('hmgetBuffer', () => {
     });
     return redis
       .hmgetBuffer('user:1', 'id', 'email', 'location')
-      .then(values => {
+      .then((values) => {
         expect(Buffer.isBuffer(values[0])).toBeTruthy();
         expect(Buffer.isBuffer(values[1])).toBeTruthy();
         expect(Buffer.isBuffer(values[2])).toBeFalsy();
@@ -28,6 +28,6 @@ describe('hmgetBuffer', () => {
     const redis = new MockRedis();
     return redis
       .hmgetBuffer('user:1', 'id', 'email', 'location')
-      .then(values => expect(values).toEqual([null, null, null]));
+      .then((values) => expect(values).toEqual([null, null, null]));
   });
 });

--- a/test/commands/hmset.js
+++ b/test/commands/hmset.js
@@ -8,7 +8,7 @@ describe('hmset', () => {
     const hash = { id: '1', email: 'bruce@wayne.enterprises' };
     return redis
       .hmset('user:1', 'id', '1', 'email', 'bruce@wayne.enterprises')
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => expect(redis.data.get('user:1')).toEqual(hash));
   });
 
@@ -17,7 +17,7 @@ describe('hmset', () => {
     const hash = { id: '1', email: 'bruce@wayne.enterprises' };
     return redis
       .hmset('user:1', hash)
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => expect(redis.data.get('user:1')).toEqual(hash));
   });
 });

--- a/test/commands/hscan.js
+++ b/test/commands/hscan.js
@@ -15,7 +15,7 @@ describe('hscan', () => {
 
   it('should return null array if hset does not exist', () => {
     const redis = new MockRedis();
-    return redis.hscan('key', 0).then(result => {
+    return redis.hscan('key', 0).then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual([]);
     });
@@ -28,7 +28,7 @@ describe('hscan', () => {
       },
     });
 
-    return redis.hscan('hset', 0).then(result => {
+    return redis.hscan('hset', 0).then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo', 'bar', 'baz']);
     });
@@ -41,7 +41,7 @@ describe('hscan', () => {
       },
     });
 
-    return redis.hscan('hset', 0, 'MATCH', 'foo*').then(result => {
+    return redis.hscan('hset', 0, 'MATCH', 'foo*').then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo0', 'foo1', 'foo2']);
     });
@@ -56,12 +56,12 @@ describe('hscan', () => {
 
     return redis
       .hscan('hset', 0, 'MATCH', 'foo*', 'COUNT', 1)
-      .then(result => {
+      .then((result) => {
         expect(result[0]).toBe('1'); // more elements left, this is why cursor is not 0
         expect(result[1]).toEqual(['foo0']);
         return redis.hscan('hset', result[0], 'MATCH', 'foo*', 'COUNT', 10);
       })
-      .then(result2 => {
+      .then((result2) => {
         expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['foo1', 'foo2']);
       });
@@ -76,12 +76,12 @@ describe('hscan', () => {
 
     return redis
       .hscan('hset', 0, 'COUNT', 3)
-      .then(result => {
+      .then((result) => {
         expect(result[0]).toBe('3');
         expect(result[1]).toEqual(['foo0', 'foo1', 'bar0']);
         return redis.hscan('hset', result[0], 'COUNT', 3);
       })
-      .then(result2 => {
+      .then((result2) => {
         expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['bar1']);
       });
@@ -89,31 +89,31 @@ describe('hscan', () => {
 
   it('should fail if incorrect cursor', () => {
     const redis = new MockRedis();
-    return redis.hscan('key', 'ZU').catch(result => {
+    return redis.hscan('key', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect command', () => {
     const redis = new MockRedis();
-    return redis.hscan('key', 0, 'ZU').catch(result => {
+    return redis.hscan('key', 0, 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect MATCH usage', () => {
     const redis = new MockRedis();
-    return redis.hscan('key', 0, 'MATCH', 'pattern', 'ZU').catch(result => {
+    return redis.hscan('key', 0, 'MATCH', 'pattern', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect COUNT usage', () => {
     const redis = new MockRedis();
-    return redis.hscan('key', 0, 'COUNT', 10, 'ZU').catch(result => {
+    return redis.hscan('key', 0, 'COUNT', 10, 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect COUNT usage 2', () => {
     const redis = new MockRedis();
-    return redis.hscan('key', 0, 'COUNT', 'ZU').catch(result => {
+    return redis.hscan('key', 0, 'COUNT', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
@@ -121,7 +121,7 @@ describe('hscan', () => {
     const redis = new MockRedis();
     return redis
       .hscan('key', 0, 'MATCH', 'foo*', 'COUNT', 1, 'ZU')
-      .catch(result => {
+      .catch((result) => {
         expect(result).toBeA(Error);
         expect(result.message).toEqual('Too many arguments');
       });
@@ -129,7 +129,7 @@ describe('hscan', () => {
 
   it('should fail if arguments length not odd', () => {
     const redis = new MockRedis();
-    return redis.hscan('key', 0, 'MATCH', 'foo*', 'COUNT').catch(result => {
+    return redis.hscan('key', 0, 'MATCH', 'foo*', 'COUNT').catch((result) => {
       expect(result).toBeA(Error);
       expect(result.message).toEqual(
         'Args should be provided by pair (name & value)'

--- a/test/commands/hscanStream.js
+++ b/test/commands/hscanStream.js
@@ -8,15 +8,15 @@ const chance = new Chance();
 
 describe('hscanStream', () => {
   let writable;
-  const flatten = wrt => _.flatten(wrt.data);
+  const flatten = (wrt) => _.flatten(wrt.data);
   const randomCCType = () => chance.cc_type({ raw: true });
-  const createHashSet = keys => _.zipObject(keys, keys.map(randomCCType));
+  const createHashSet = (keys) => _.zipObject(keys, keys.map(randomCCType));
 
   beforeEach(() => {
     writable = new ObjectWritableMock();
   });
 
-  it('should return null array if nothing in db', done => {
+  it('should return null array if nothing in db', (done) => {
     // Given
     const redis = new MockRedis();
     const stream = redis.hscanStream('key');
@@ -29,7 +29,7 @@ describe('hscanStream', () => {
     });
   });
 
-  it('should return keys in db', done => {
+  it('should return keys in db', (done) => {
     const redis = new MockRedis({
       data: {
         hset: createHashSet(['foo', 'bar']),
@@ -45,7 +45,7 @@ describe('hscanStream', () => {
     });
   });
 
-  it('should batch by count', done => {
+  it('should batch by count', (done) => {
     // Given
     const keys = chance.unique(chance.word, 100);
     const count = 11;
@@ -61,7 +61,7 @@ describe('hscanStream', () => {
     });
   });
 
-  it('should return only mathced keys', done => {
+  it('should return only mathced keys', (done) => {
     // Given
     const redis = new MockRedis({
       data: {
@@ -78,7 +78,7 @@ describe('hscanStream', () => {
     });
   });
 
-  it('should return only mathced keys by count', done => {
+  it('should return only mathced keys by count', (done) => {
     // Given
     const redis = new MockRedis({
       data: {
@@ -96,7 +96,7 @@ describe('hscanStream', () => {
     });
   });
 
-  it('should fail if incorrect count usage', done => {
+  it('should fail if incorrect count usage', (done) => {
     // Given
     const redis = new MockRedis({
       data: {
@@ -106,7 +106,7 @@ describe('hscanStream', () => {
     const stream = redis.hscanStream('hset', { count: 'ZU' });
     // When
     stream.pipe(writable);
-    stream.on('error', err => {
+    stream.on('error', (err) => {
       // Then
       expect(err).toBeA(Error);
       done();

--- a/test/commands/hset.js
+++ b/test/commands/hset.js
@@ -8,7 +8,7 @@ describe('hset', () => {
   it('should return 1 when setting a new field', () =>
     redis
       .hset('user:1', 'email', 'clark@daily.planet')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() =>
         expect(redis.data.get('user:1')).toEqual({
           email: 'clark@daily.planet',
@@ -18,7 +18,7 @@ describe('hset', () => {
   it('should return 0 when overwriting existing field', () =>
     redis
       .hset('user:1', 'email', 'bruce@wayne.enterprises')
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() =>
         expect(redis.data.get('user:1')).toEqual({
           email: 'bruce@wayne.enterprises',

--- a/test/commands/hsetnx.js
+++ b/test/commands/hsetnx.js
@@ -7,7 +7,7 @@ describe('hsetnx', () => {
     const redis = new MockRedis();
     return redis
       .hsetnx('emails', 'bruce@wayne.enterprises', '1')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => {
         expect(redis.data.get('emails')['bruce@wayne.enterprises']).toBe(
           '1',
@@ -15,7 +15,7 @@ describe('hsetnx', () => {
         );
         return redis.hsetnx('emails', 'bruce@wayne.enterprises', '2');
       })
-      .then(status =>
+      .then((status) =>
         expect(status).toBe(0, 'hsetnx no-op failed on existing key')
       )
       .then(() => {

--- a/test/commands/hstrlen.js
+++ b/test/commands/hstrlen.js
@@ -6,7 +6,9 @@ describe('hstrlen', () => {
   it('should return 0 on keys that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.hstrlen('nonexisting').then(result => expect(result).toBe(0));
+    return redis
+      .hstrlen('nonexisting')
+      .then((result) => expect(result).toBe(0));
   });
 
   it('should return 0 on fields that do not exist', () => {
@@ -14,7 +16,7 @@ describe('hstrlen', () => {
 
     return redis
       .hstrlen('nonexisting', 'foo')
-      .then(result => expect(result).toBe(0));
+      .then((result) => expect(result).toBe(0));
   });
 
   it('should return length on existing fields', () => {
@@ -28,6 +30,6 @@ describe('hstrlen', () => {
 
     return redis
       .hstrlen('mykey', 'foo')
-      .then(result => expect(result).toBe(11));
+      .then((result) => expect(result).toBe(11));
   });
 });

--- a/test/commands/hvals.js
+++ b/test/commands/hvals.js
@@ -15,12 +15,12 @@ describe('hvals', () => {
 
     return redis
       .hvals('emails')
-      .then(result => expect(result).toEqual(['1', '2']));
+      .then((result) => expect(result).toEqual(['1', '2']));
   });
 
   it("should return empty array if sources don't exists", () => {
     const redis = new MockRedis();
 
-    return redis.hvals('emails').then(result => expect(result).toEqual([]));
+    return redis.hvals('emails').then((result) => expect(result).toEqual([]));
   });
 });

--- a/test/commands/incr.js
+++ b/test/commands/incr.js
@@ -12,7 +12,7 @@ describe('incr', () => {
 
     return redis
       .incr('user_next')
-      .then(userNext => expect(userNext).toBe(2))
+      .then((userNext) => expect(userNext).toBe(2))
       .then(() => expect(redis.data.get('user_next')).toBe('2'));
   });
 
@@ -21,7 +21,7 @@ describe('incr', () => {
 
     return redis
       .incr('user_next')
-      .then(userNext => expect(userNext).toBe(1))
+      .then((userNext) => expect(userNext).toBe(1))
       .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
 });

--- a/test/commands/incrby.js
+++ b/test/commands/incrby.js
@@ -10,7 +10,7 @@ describe('incrby', () => {
 
     return redis
       .incrby('user_next', 10)
-      .then(userNext => expect(userNext).toBe(10))
+      .then((userNext) => expect(userNext).toBe(10))
       .then(() => expect(redis.data.get('user_next')).toBe('10'));
   });
   it('should increment an integer with passed increment', () => {
@@ -22,7 +22,7 @@ describe('incrby', () => {
 
     return redis
       .incrby('user_next', 10)
-      .then(userNext => expect(userNext).toBe(11))
+      .then((userNext) => expect(userNext).toBe(11))
       .then(() => expect(redis.data.get('user_next')).toBe('11'));
   });
   it('should not increment if no increment is passed', () => {
@@ -34,7 +34,7 @@ describe('incrby', () => {
 
     return redis
       .incrby('user_next')
-      .then(userNext => expect(userNext).toBe(1))
+      .then((userNext) => expect(userNext).toBe(1))
       .then(() => expect(redis.data.get('user_next')).toBe('1'));
   });
 });

--- a/test/commands/incrbyfloat.js
+++ b/test/commands/incrbyfloat.js
@@ -10,7 +10,7 @@ describe('incrbyfloat', () => {
 
     return redis
       .incrbyfloat('user_next', 10.1)
-      .then(userNext => expect(userNext).toBe('10.1'))
+      .then((userNext) => expect(userNext).toBe('10.1'))
       .then(() => expect(redis.data.get('user_next')).toBe('10.1'));
   });
   it('should increment an float with passed increment', () => {
@@ -22,9 +22,9 @@ describe('incrbyfloat', () => {
 
     return redis
       .incrbyfloat('mykey', 0.1)
-      .then(result => expect(result).toBe('10.6'))
+      .then((result) => expect(result).toBe('10.6'))
       .then(() => redis.incrbyfloat('mykey', -5))
-      .then(result => expect(result).toBe('5.6'))
+      .then((result) => expect(result).toBe('5.6'))
       .then(() => expect(redis.data.get('mykey')).toBe('5.6'));
   });
 
@@ -37,7 +37,7 @@ describe('incrbyfloat', () => {
 
     return redis
       .incrbyfloat('mykey', '2.0e2')
-      .then(result => expect(result).toBe('5200'))
+      .then((result) => expect(result).toBe('5200'))
       .then(() => expect(redis.data.get('mykey')).toBe('5200'));
   });
 });

--- a/test/commands/info.js
+++ b/test/commands/info.js
@@ -11,13 +11,13 @@ describe('info', () => {
         info,
       },
     });
-    return redis.info().then(value => {
+    return redis.info().then((value) => {
       expect(value).toEqual(info);
     });
   });
   it('should return default info', () => {
     const redis = new MockRedis();
-    return redis.info().then(value => {
+    return redis.info().then((value) => {
       expect(value).toMatch(/redis_version/g);
     });
   });

--- a/test/commands/keys.js
+++ b/test/commands/keys.js
@@ -6,7 +6,7 @@ describe('keys', () => {
   it('should return an empty array if there are no keys', () => {
     const redis = new MockRedis();
 
-    return redis.keys('*').then(result => expect(result).toEqual([]));
+    return redis.keys('*').then((result) => expect(result).toEqual([]));
   });
 
   it('should return all data keys', () => {
@@ -19,7 +19,7 @@ describe('keys', () => {
 
     return redis
       .keys('*')
-      .then(result => expect(result).toEqual(['foo', 'baz']));
+      .then((result) => expect(result).toEqual(['foo', 'baz']));
   });
 
   it('should only return keys matching the given pattern', () => {
@@ -33,7 +33,7 @@ describe('keys', () => {
 
     return redis
       .keys('f*')
-      .then(result => expect(result).toEqual(['foo', 'flambé']));
+      .then((result) => expect(result).toEqual(['foo', 'flambé']));
   });
 
   it('should not return empty sets', () => {
@@ -43,6 +43,6 @@ describe('keys', () => {
       .sadd('a', 'b')
       .then(() => redis.srem('a', 'b'))
       .then(() => redis.keys('*'))
-      .then(result => expect(result).toEqual([]));
+      .then((result) => expect(result).toEqual([]));
   });
 });

--- a/test/commands/lastsave.js
+++ b/test/commands/lastsave.js
@@ -8,7 +8,7 @@ describe('lastsave', () => {
 
     return redis
       .lastsave()
-      .then(result =>
+      .then((result) =>
         expect(result).toBeLessThanOrEqualTo(
           Math.floor(new Date().getTime() / 1000)
         )

--- a/test/commands/lindex.js
+++ b/test/commands/lindex.js
@@ -12,11 +12,11 @@ describe('lindex', () => {
 
     return redis
       .lindex('mylist', 0)
-      .then(result => expect(result).toBe('Hello'))
+      .then((result) => expect(result).toBe('Hello'))
       .then(() => redis.lindex('mylist', -1))
-      .then(result => expect(result).toBe('World'))
+      .then((result) => expect(result).toBe('World'))
       .then(() => redis.lindex('mylist', 3))
-      .then(result => expect(result).toBe(null));
+      .then((result) => expect(result).toBe(null));
   });
 
   it('should return null if the list does not exist', () => {
@@ -24,7 +24,7 @@ describe('lindex', () => {
       data: {},
     });
 
-    return redis.lindex('foo', 0).then(result => expect(result).toBe(null));
+    return redis.lindex('foo', 0).then((result) => expect(result).toBe(null));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -36,7 +36,7 @@ describe('lindex', () => {
 
     return redis
       .lindex('foo', 0)
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });

--- a/test/commands/llen.js
+++ b/test/commands/llen.js
@@ -10,7 +10,7 @@ describe('llen', () => {
       },
     });
 
-    return redis.llen('foo').then(length => expect(length).toBe(3));
+    return redis.llen('foo').then((length) => expect(length).toBe(3));
   });
 
   it('should return 0 if the list does not exist', () => {
@@ -18,7 +18,7 @@ describe('llen', () => {
       data: {},
     });
 
-    return redis.llen('foo').then(length => expect(length).toBe(0));
+    return redis.llen('foo').then((length) => expect(length).toBe(0));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -30,7 +30,7 @@ describe('llen', () => {
 
     return redis
       .llen('foo')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });

--- a/test/commands/lpop.js
+++ b/test/commands/lpop.js
@@ -12,7 +12,7 @@ describe('lpop', () => {
 
     return redis
       .lpop('foo')
-      .then(result => expect(result).toBe('3'))
+      .then((result) => expect(result).toBe('3'))
       .then(() => expect(redis.data.get('foo')).toEqual(['2', '1']));
   });
 
@@ -23,7 +23,7 @@ describe('lpop', () => {
       },
     });
 
-    return redis.lpop('foo').then(result => expect(result).toBe(null));
+    return redis.lpop('foo').then((result) => expect(result).toBe(null));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -35,7 +35,7 @@ describe('lpop', () => {
 
     return redis
       .lpop('foo')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });

--- a/test/commands/lpopBuffer.js
+++ b/test/commands/lpopBuffer.js
@@ -13,7 +13,7 @@ describe('lpopBuffer', () => {
 
     return redis
       .lpopBuffer('foo')
-      .then(result => expect(result).toEqual(createBuffer('3')))
+      .then((result) => expect(result).toEqual(createBuffer('3')))
       .then(() => expect(redis.data.get('foo')).toEqual(['2', '1']));
   });
 
@@ -27,12 +27,12 @@ describe('lpopBuffer', () => {
 
     return redis
       .lpopBuffer('foo')
-      .then(result => {
+      .then((result) => {
         expect(Buffer.isBuffer(result)).toBeTruthy();
         expect(result).toEqual(bufferVal);
         return redis.lpopBuffer('foo');
       })
-      .then(result => {
+      .then((result) => {
         expect(Buffer.isBuffer(result)).toBeTruthy();
         expect(result).toEqual(createBuffer('2'));
       });
@@ -45,7 +45,7 @@ describe('lpopBuffer', () => {
       },
     });
 
-    return redis.lpopBuffer('foo').then(result => expect(result).toBe(null));
+    return redis.lpopBuffer('foo').then((result) => expect(result).toBe(null));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -57,7 +57,7 @@ describe('lpopBuffer', () => {
 
     return redis
       .lpopBuffer('foo')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });

--- a/test/commands/lpush.js
+++ b/test/commands/lpush.js
@@ -20,7 +20,7 @@ describe('lpush', () => {
       data: {},
     });
 
-    return redis.lpush('foo', 9, 8, 7).then(length => expect(length).toBe(3));
+    return redis.lpush('foo', 9, 8, 7).then((length) => expect(length).toBe(3));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -32,7 +32,7 @@ describe('lpush', () => {
 
     return redis
       .lpush('foo', 1)
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });

--- a/test/commands/lpushx.js
+++ b/test/commands/lpushx.js
@@ -22,12 +22,12 @@ describe('lpushx', () => {
       },
     });
 
-    return redis.lpushx('foo', 1).then(result => expect(result).toBe(2));
+    return redis.lpushx('foo', 1).then((result) => expect(result).toBe(2));
   });
 
   it('should return 0 if list does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.lpushx('foo', 1).then(result => expect(result).toBe(0));
+    return redis.lpushx('foo', 1).then((result) => expect(result).toBe(0));
   });
 });

--- a/test/commands/lrange.js
+++ b/test/commands/lrange.js
@@ -12,7 +12,7 @@ describe('lrange', () => {
 
     return redis
       .lrange('foo', 0, 2)
-      .then(res => expect(res).toEqual(['1', '2', '3']));
+      .then((res) => expect(res).toEqual(['1', '2', '3']));
   });
 
   it('should return last 3 items', () => {
@@ -24,7 +24,7 @@ describe('lrange', () => {
 
     return redis
       .lrange('foo', -3, -1)
-      .then(res => expect(res).toEqual(['3', '4', '5']));
+      .then((res) => expect(res).toEqual(['3', '4', '5']));
   });
 
   it('should return last all items on larger numbers', () => {
@@ -36,7 +36,7 @@ describe('lrange', () => {
 
     return redis
       .lrange('foo', 0, 100)
-      .then(res => expect(res).toEqual(['1', '2', '3', '4', '5']));
+      .then((res) => expect(res).toEqual(['1', '2', '3', '4', '5']));
   });
 
   it('should return empty array if out-of-range', () => {
@@ -46,7 +46,7 @@ describe('lrange', () => {
       },
     });
 
-    return redis.lrange('foo', 10, 100).then(res => expect(res).toEqual([]));
+    return redis.lrange('foo', 10, 100).then((res) => expect(res).toEqual([]));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -58,7 +58,7 @@ describe('lrange', () => {
 
     return redis
       .lrange('foo', 0, 2)
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });

--- a/test/commands/lrem.js
+++ b/test/commands/lrem.js
@@ -48,7 +48,7 @@ describe('lrem', () => {
 
     return redis
       .lrem('foo', -2, 'baz')
-      .then(removed => expect(removed).toBe(1));
+      .then((removed) => expect(removed).toBe(1));
   });
 
   it('should return 0 if the key contains something other than a list', () => {
@@ -58,6 +58,6 @@ describe('lrem', () => {
       },
     });
 
-    return redis.lrem('foo', 1).then(removed => expect(removed).toBe(0));
+    return redis.lrem('foo', 1).then((removed) => expect(removed).toBe(0));
   });
 });

--- a/test/commands/lset.js
+++ b/test/commands/lset.js
@@ -12,9 +12,9 @@ describe('lset', () => {
 
     return redis
       .lset('mylist', 0, 'four')
-      .then(result => expect(result).toBe('OK'))
+      .then((result) => expect(result).toBe('OK'))
       .then(() => redis.lset('mylist', -2, 'five'))
-      .then(result => expect(result).toBe('OK'))
+      .then((result) => expect(result).toBe('OK'))
       .then(() =>
         expect(redis.data.get('mylist')).toEqual(['four', 'five', 'three'])
       );
@@ -25,7 +25,7 @@ describe('lset', () => {
 
     return redis
       .lset('mylist', 0, 'foo')
-      .catch(err => expect(err.message).toBe('no such key'));
+      .catch((err) => expect(err.message).toBe('no such key'));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -37,7 +37,7 @@ describe('lset', () => {
 
     return redis
       .lset('foo', 0, 'bar')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });
@@ -51,11 +51,11 @@ describe('lset', () => {
 
     return redis
       .lset('mylist', 5, 'four')
-      .catch(err => {
+      .catch((err) => {
         expect(err.message).toBe('index out of range');
 
         return redis.lset('mylist', -5, 'five');
       })
-      .catch(err => expect(err.message).toBe('index out of range'));
+      .catch((err) => expect(err.message).toBe('index out of range'));
   });
 });

--- a/test/commands/mget.js
+++ b/test/commands/mget.js
@@ -6,7 +6,7 @@ describe('mget', () => {
   it('should return null on keys that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.mget('foo').then(result => expect(result).toEqual([null]));
+    return redis.mget('foo').then((result) => expect(result).toEqual([null]));
   });
 
   it('should return value keys that exist', () => {
@@ -18,6 +18,6 @@ describe('mget', () => {
 
     return redis
       .mget('foo', 'hello')
-      .then(result => expect(result).toEqual(['bar', null]));
+      .then((result) => expect(result).toEqual(['bar', null]));
   });
 });

--- a/test/commands/mset.js
+++ b/test/commands/mset.js
@@ -7,7 +7,7 @@ describe('mset', () => {
     const redis = new MockRedis();
     return redis
       .mset('key1', 'Hello', 'key2', 'World')
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => {
         expect(redis.data.get('key1')).toBe('Hello');
         expect(redis.data.get('key2')).toBe('World');

--- a/test/commands/msetnx.js
+++ b/test/commands/msetnx.js
@@ -7,7 +7,7 @@ describe('msetnx', () => {
     const redis = new MockRedis();
     return redis
       .msetnx('key1', 'Hello', 'key2', 'World')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => {
         expect(redis.data.get('key1')).toBe('Hello');
         expect(redis.data.get('key2')).toBe('World');
@@ -22,7 +22,7 @@ describe('msetnx', () => {
     });
     return redis
       .msetnx('key1', 'Hello', 'key2', 'World')
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() => {
         expect(redis.data.get('key1')).toBe('Nope');
         expect(redis.data.has('key2')).toBe(false);

--- a/test/commands/persist.js
+++ b/test/commands/persist.js
@@ -12,7 +12,7 @@ describe('persist', () => {
     return redis
       .expire('foo', 1)
       .then(() => redis.persist('foo'))
-      .then(status => {
+      .then((status) => {
         expect(status).toBe(1);
         expect(redis.expires.has('foo')).toBe(false);
       });
@@ -24,12 +24,12 @@ describe('persist', () => {
         foo: 'bar',
       },
     });
-    return redis.persist('foo').then(status => expect(status).toBe(0));
+    return redis.persist('foo').then((status) => expect(status).toBe(0));
   });
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.persist('foo').then(status => expect(status).toBe(0));
+    return redis.persist('foo').then((status) => expect(status).toBe(0));
   });
 });

--- a/test/commands/pexpire.js
+++ b/test/commands/pexpire.js
@@ -12,20 +12,20 @@ describe('pexpire', () => {
     });
     return redis
       .pexpire('foo', 100)
-      .then(status => {
+      .then((status) => {
         expect(status).toBe(1);
         expect(redis.expires.has('foo')).toBe(true);
 
         return redis.pttl('foo');
       })
-      .then(result => expect(result).toBeGreaterThanOrEqualTo(1))
+      .then((result) => expect(result).toBeGreaterThanOrEqualTo(1))
       .then(() => Promise.delay(200))
       .then(() => redis.get('foo'))
-      .then(result => expect(result).toBe(null));
+      .then((result) => expect(result).toBe(null));
   });
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
-    return redis.pexpire('foo', 100).then(status => expect(status).toBe(0));
+    return redis.pexpire('foo', 100).then((status) => expect(status).toBe(0));
   });
 });

--- a/test/commands/pexpireat.js
+++ b/test/commands/pexpireat.js
@@ -13,21 +13,21 @@ describe('pexpireat', () => {
     const at = Date.now() + 100;
     return redis
       .pexpireat('foo', at)
-      .then(status => {
+      .then((status) => {
         expect(status).toBe(1);
         expect(redis.expires.has('foo')).toBe(true);
 
         return redis.ttl('foo');
       })
-      .then(result => expect(result).toBeGreaterThanOrEqualTo(1))
+      .then((result) => expect(result).toBeGreaterThanOrEqualTo(1))
       .then(() => Promise.delay(200))
       .then(() => redis.get('foo'))
-      .then(result => expect(result).toBe(null));
+      .then((result) => expect(result).toBe(null));
   });
 
   it('should return 0 if key does not exist', () => {
     const redis = new MockRedis();
     const at = Date.now();
-    return redis.pexpireat('foo', at).then(status => expect(status).toBe(0));
+    return redis.pexpireat('foo', at).then((status) => expect(status).toBe(0));
   });
 });

--- a/test/commands/ping.js
+++ b/test/commands/ping.js
@@ -6,7 +6,7 @@ describe('ping', () => {
   it('should return PONG', () => {
     const redis = new MockRedis();
 
-    return redis.ping().then(result => expect(result).toBe('PONG'));
+    return redis.ping().then((result) => expect(result).toBe('PONG'));
   });
 
   it('should return message', () => {
@@ -14,6 +14,6 @@ describe('ping', () => {
 
     return redis
       .ping('Hello World!')
-      .then(result => expect(result).toBe('Hello World!'));
+      .then((result) => expect(result).toBe('Hello World!'));
   });
 });

--- a/test/commands/psetex.js
+++ b/test/commands/psetex.js
@@ -8,13 +8,13 @@ describe('psetex', () => {
     const redis = new MockRedis();
     return redis
       .psetex('foo', 100, 'bar')
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => {
         expect(redis.data.get('foo')).toBe('bar');
         expect(redis.expires.has('foo')).toBe(true);
       })
       .then(() => Promise.delay(200))
       .then(() => redis.get('foo'))
-      .then(result => expect(result).toBe(null));
+      .then((result) => expect(result).toBe(null));
   });
 });

--- a/test/commands/psubscribe.js
+++ b/test/commands/psubscribe.js
@@ -7,16 +7,16 @@ describe('psubscribe', () => {
     const redis = new MockRedis();
     return redis
       .psubscribe('news.*', 'music.*')
-      .then(subNum => expect(subNum).toBe(2));
+      .then((subNum) => expect(subNum).toBe(2));
   });
 
   it('should return number of subscribed channels when calling subscribe twice', () => {
     const redis = new MockRedis();
     return redis
       .psubscribe('first.*')
-      .then(subNum => expect(subNum).toBe(1))
+      .then((subNum) => expect(subNum).toBe(1))
       .then(() =>
-        redis.psubscribe('second.*').then(subNum => expect(subNum).toBe(2))
+        redis.psubscribe('second.*').then((subNum) => expect(subNum).toBe(2))
       );
   });
 
@@ -24,9 +24,9 @@ describe('psubscribe', () => {
     const redis = new MockRedis();
     return redis
       .psubscribe('channel.*')
-      .then(subNum => expect(subNum).toBe(1))
+      .then((subNum) => expect(subNum).toBe(1))
       .then(() =>
-        redis.psubscribe('channel.*').then(subNum => expect(subNum).toBe(1))
+        redis.psubscribe('channel.*').then((subNum) => expect(subNum).toBe(1))
       );
   });
 
@@ -38,7 +38,7 @@ describe('psubscribe', () => {
         .then(() => {
           throw new Error('get should fail when in subscriber mode');
         })
-        .catch(error =>
+        .catch((error) =>
           expect(error.message).toBe(
             'Connection in subscriber mode, only subscriber commands may be used'
           )
@@ -58,10 +58,10 @@ describe('psubscribe', () => {
       expect(twoResult).toEqual(1);
       let promiseOneFulfill;
       let PromiseTwoFulfill;
-      const promiseOne = new Promise(f => {
+      const promiseOne = new Promise((f) => {
         promiseOneFulfill = f;
       });
-      const promiseTwo = new Promise(f => {
+      const promiseTwo = new Promise((f) => {
         PromiseTwoFulfill = f;
       });
 

--- a/test/commands/pttl.js
+++ b/test/commands/pttl.js
@@ -6,7 +6,7 @@ describe('pttl', () => {
   it('should return -2 if key does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.pttl('foo').then(result => expect(result).toBe(-2));
+    return redis.pttl('foo').then((result) => expect(result).toBe(-2));
   });
 
   it('should return -1 if key exist but have no expire', () => {
@@ -16,7 +16,7 @@ describe('pttl', () => {
       },
     });
 
-    return redis.pttl('foo').then(result => expect(result).toBe(-1));
+    return redis.pttl('foo').then((result) => expect(result).toBe(-1));
   });
 
   it('should return seconds left until expire', () => {
@@ -29,6 +29,6 @@ describe('pttl', () => {
     return redis
       .expire('foo', 1)
       .then(() => redis.pttl('foo'))
-      .then(result => expect(result).toBeGreaterThan(0));
+      .then((result) => expect(result).toBeGreaterThan(0));
   });
 });

--- a/test/commands/publish.js
+++ b/test/commands/publish.js
@@ -7,7 +7,7 @@ describe('publish', () => {
     const redis = new MockRedis();
     return redis
       .publish('emails', 'clark@daily.planet')
-      .then(subscribers => expect(subscribers).toBe(0));
+      .then((subscribers) => expect(subscribers).toBe(0));
   });
 
   it('should return 1 when publishing with a single subscriber', () => {
@@ -16,10 +16,10 @@ describe('publish', () => {
     redisPubSub.subscribe('emails');
     return redis2
       .publish('emails', 'clark@daily.planet')
-      .then(subscribers => expect(subscribers).toBe(1));
+      .then((subscribers) => expect(subscribers).toBe(1));
   });
 
-  it('should publish a message, which can be received by a previous subscribe', done => {
+  it('should publish a message, which can be received by a previous subscribe', (done) => {
     const redisPubSub = new MockRedis();
     const redis2 = redisPubSub.createConnectedClient();
     redisPubSub.on('message', (channel, message) => {
@@ -37,10 +37,10 @@ describe('publish', () => {
     redisPubSub.psubscribe('emails.*');
     return redis2
       .publish('emails.urgent', 'clark@daily.planet')
-      .then(subscribers => expect(subscribers).toBe(1));
+      .then((subscribers) => expect(subscribers).toBe(1));
   });
 
-  it('should publish a message, which can be received by a previous psubscribe', done => {
+  it('should publish a message, which can be received by a previous psubscribe', (done) => {
     const redisPubSub = new MockRedis();
     const redis2 = redisPubSub.createConnectedClient();
     redisPubSub.on('message', (channel, message) => {

--- a/test/commands/punsubscribe.js
+++ b/test/commands/punsubscribe.js
@@ -7,26 +7,28 @@ describe('punsubscribe', () => {
     const redis = new MockRedis();
     // unsubscribe returns the number of open channels (like subscribe)
     // unsubscribe() should always return 0, as we have unsubscribed from all channels
-    return redis.punsubscribe().then(subNum => expect(subNum).toBe(0));
+    return redis.punsubscribe().then((subNum) => expect(subNum).toBe(0));
   });
 
   it('should return 0 when no arguments are given after being subscribed to a channel', () => {
     const redis = new MockRedis();
     return redis
       .psubscribe('first')
-      .then(subNum => expect(subNum).toBe(1))
-      .then(() => redis.punsubscribe().then(subNum => expect(subNum).toBe(0)));
+      .then((subNum) => expect(subNum).toBe(1))
+      .then(() =>
+        redis.punsubscribe().then((subNum) => expect(subNum).toBe(0))
+      );
   });
 
   it('should return the number of subscribed channels when unsubscribing from a subscribed channel', () => {
     const redis = new MockRedis();
     return redis
       .psubscribe('first.*', 'second.*', 'third.*')
-      .then(subNum => expect(subNum).toBe(3))
+      .then((subNum) => expect(subNum).toBe(3))
       .then(() =>
         redis
           .punsubscribe('second.*', 'third.*')
-          .then(subNum => expect(subNum).toBe(1))
+          .then((subNum) => expect(subNum).toBe(1))
       );
   });
 
@@ -34,7 +36,7 @@ describe('punsubscribe', () => {
     const redis = new MockRedis();
     return redis
       .punsubscribe('fourth.*')
-      .then(subNum => expect(subNum).toBe(0));
+      .then((subNum) => expect(subNum).toBe(0));
   });
 
   it('should unsubscribe only one instance when more than one is subscribed to a channel', () => {
@@ -48,11 +50,11 @@ describe('punsubscribe', () => {
       .then(() => {
         return redisTwo.punsubscribe('first.*');
       })
-      .then(result => {
+      .then((result) => {
         expect(result).toEqual(1);
 
         let promiseFulfill;
-        const promise = new Promise(f => {
+        const promise = new Promise((f) => {
           promiseFulfill = f;
         });
 

--- a/test/commands/quit.js
+++ b/test/commands/quit.js
@@ -5,5 +5,5 @@ import MockRedis from '../../src';
 describe('quit', () => {
   const redis = new MockRedis();
   it('should return OK', () =>
-    redis.quit().then(res => expect(res).toBe('OK')));
+    redis.quit().then((res) => expect(res).toBe('OK')));
 });

--- a/test/commands/randomkey.js
+++ b/test/commands/randomkey.js
@@ -13,12 +13,12 @@ describe('randomkey', () => {
 
     return redis
       .randomkey()
-      .then(result => expect(['foo', 'bar']).toInclude(result));
+      .then((result) => expect(['foo', 'bar']).toInclude(result));
   });
 
   it('should return null if db is empty', () => {
     const redis = new MockRedis();
 
-    return redis.randomkey().then(result => expect(result).toBe(null));
+    return redis.randomkey().then((result) => expect(result).toBe(null));
   });
 });

--- a/test/commands/rename.js
+++ b/test/commands/rename.js
@@ -11,14 +11,14 @@ describe('rename', () => {
     });
     return redis
       .rename('foo', 'bar')
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => {
         expect(redis.data.has('foo')).toBe(false);
         expect(redis.data.get('bar')).toBe('baz');
       });
   });
 
-  it('should emit keyspace notifications if configured', done => {
+  it('should emit keyspace notifications if configured', (done) => {
     const redis = new MockRedis({ notifyKeyspaceEvents: 'gK' }); // gK: generic Keyspace
     const redisPubSub = redis.createConnectedClient();
     let messagesReceived = 0;

--- a/test/commands/renamenx.js
+++ b/test/commands/renamenx.js
@@ -11,7 +11,7 @@ describe('renamenx', () => {
     });
     return redis
       .renamenx('foo', 'bar')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => {
         expect(redis.data.has('foo')).toBe(false);
         expect(redis.data.get('bar')).toBe('baz');
@@ -27,7 +27,7 @@ describe('renamenx', () => {
     });
     return redis
       .renamenx('foo', 'bar')
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() => {
         expect(redis.data.get('foo')).toBe('baz');
         expect(redis.data.get('bar')).toBe('foobar');

--- a/test/commands/role.js
+++ b/test/commands/role.js
@@ -6,7 +6,7 @@ describe('role', () => {
   it('should return role info on the current redis instance', () => {
     const redis = new MockRedis();
 
-    return redis.role().then(result => expect(result).toEqual(['master', 0]));
+    return redis.role().then((result) => expect(result).toEqual(['master', 0]));
   });
 
   it('should return slave info');

--- a/test/commands/rpop.js
+++ b/test/commands/rpop.js
@@ -12,7 +12,7 @@ describe('rpop', () => {
 
     return redis
       .rpop('foo')
-      .then(result => expect(result).toBe('3'))
+      .then((result) => expect(result).toBe('3'))
       .then(() => expect(redis.data.get('foo')).toEqual(['1', '2']));
   });
 
@@ -23,7 +23,7 @@ describe('rpop', () => {
       },
     });
 
-    return redis.rpop('foo').then(result => expect(result).toBe(null));
+    return redis.rpop('foo').then((result) => expect(result).toBe(null));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -35,7 +35,7 @@ describe('rpop', () => {
 
     return redis
       .rpop('foo')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });

--- a/test/commands/rpopBuffer.js
+++ b/test/commands/rpopBuffer.js
@@ -13,7 +13,7 @@ describe('rpopBuffer', () => {
 
     return redis
       .rpopBuffer('foo')
-      .then(result => expect(result).toBe('3'))
+      .then((result) => expect(result).toBe('3'))
       .then(() => expect(redis.data.get('foo')).toEqual(['1', '2']));
   });
 
@@ -27,7 +27,7 @@ describe('rpopBuffer', () => {
 
     return redis
       .rpopBuffer('foo')
-      .then(result => expect(result).toBe(bufferVal));
+      .then((result) => expect(result).toBe(bufferVal));
   });
 
   it('should return null on empty list', () => {
@@ -37,7 +37,7 @@ describe('rpopBuffer', () => {
       },
     });
 
-    return redis.rpopBuffer('foo').then(result => expect(result).toBe(null));
+    return redis.rpopBuffer('foo').then((result) => expect(result).toBe(null));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -49,7 +49,7 @@ describe('rpopBuffer', () => {
 
     return redis
       .rpopBuffer('foo')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });

--- a/test/commands/rpoplpush.js
+++ b/test/commands/rpoplpush.js
@@ -35,7 +35,7 @@ describe('rpoplpush', () => {
 
     return redis
       .rpoplpush('foo', 'bar')
-      .then(item => expect(item).toEqual(null));
+      .then((item) => expect(item).toEqual(null));
   });
 
   it('should return null if the source list is empty', () => {
@@ -47,7 +47,7 @@ describe('rpoplpush', () => {
 
     return redis
       .rpoplpush('foo', 'bar')
-      .then(item => expect(item).toEqual(null));
+      .then((item) => expect(item).toEqual(null));
   });
 
   it('should return the item', () => {
@@ -57,7 +57,9 @@ describe('rpoplpush', () => {
       },
     });
 
-    return redis.rpoplpush('foo', 'bar').then(item => expect(item).toBe('bar'));
+    return redis
+      .rpoplpush('foo', 'bar')
+      .then((item) => expect(item).toBe('bar'));
   });
 
   it('should throw an exception if the source key contains something other than a list', () => {
@@ -70,7 +72,7 @@ describe('rpoplpush', () => {
 
     return redis
       .rpoplpush('foo', 'bar')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });
@@ -85,7 +87,7 @@ describe('rpoplpush', () => {
 
     return redis
       .rpoplpush('foo', 'bar')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key bar does not contain a list')
       );
   });

--- a/test/commands/rpoplpushBuffer.js
+++ b/test/commands/rpoplpushBuffer.js
@@ -34,7 +34,7 @@ describe('rpoplpushBuffer', () => {
 
     return redis
       .rpoplpushBuffer('foo', 'bar')
-      .then(item => expect(item).toEqual(null));
+      .then((item) => expect(item).toEqual(null));
   });
 
   it('should return null if the source list is empty', () => {
@@ -46,7 +46,7 @@ describe('rpoplpushBuffer', () => {
 
     return redis
       .rpoplpushBuffer('foo', 'bar')
-      .then(item => expect(item).toEqual(null));
+      .then((item) => expect(item).toEqual(null));
   });
 
   it('should return the item', () => {
@@ -58,7 +58,7 @@ describe('rpoplpushBuffer', () => {
 
     return redis
       .rpoplpushBuffer('foo', 'bar')
-      .then(item => expect(item).toBe('bar'));
+      .then((item) => expect(item).toBe('bar'));
   });
 
   it('should return buffer values correctly', () => {
@@ -71,7 +71,7 @@ describe('rpoplpushBuffer', () => {
 
     return redis
       .rpoplpushBuffer('foo', bufferVal)
-      .then(item => expect(item).toBe(bufferVal));
+      .then((item) => expect(item).toBe(bufferVal));
   });
 
   it('should throw an exception if the source key contains something other than a list', () => {
@@ -84,7 +84,7 @@ describe('rpoplpushBuffer', () => {
 
     return redis
       .rpoplpushBuffer('foo', 'bar')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });
@@ -99,7 +99,7 @@ describe('rpoplpushBuffer', () => {
 
     return redis
       .rpoplpushBuffer('foo', 'bar')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key bar does not contain a list')
       );
   });

--- a/test/commands/rpush.js
+++ b/test/commands/rpush.js
@@ -18,7 +18,7 @@ describe('rpush', () => {
   it('should return the new length of the list', () => {
     const redis = new MockRedis();
 
-    return redis.rpush('foo', 9, 8, 7).then(length => expect(length).toBe(3));
+    return redis.rpush('foo', 9, 8, 7).then((length) => expect(length).toBe(3));
   });
 
   it('should throw an exception if the key contains something other than a list', () => {
@@ -30,7 +30,7 @@ describe('rpush', () => {
 
     return redis
       .rpush('foo', 1)
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a list')
       );
   });

--- a/test/commands/rpushx.js
+++ b/test/commands/rpushx.js
@@ -22,12 +22,12 @@ describe('rpushx', () => {
       },
     });
 
-    return redis.rpushx('foo', 2).then(result => expect(result).toBe(2));
+    return redis.rpushx('foo', 2).then((result) => expect(result).toBe(2));
   });
 
   it('should return 0 if list does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.rpushx('foo', 1).then(result => expect(result).toBe(0));
+    return redis.rpushx('foo', 1).then((result) => expect(result).toBe(0));
   });
 });

--- a/test/commands/sadd.js
+++ b/test/commands/sadd.js
@@ -8,7 +8,7 @@ describe('sadd', () => {
 
     return redis
       .sadd('foos', 'bar')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => expect(redis.data.get('foos').has('bar')).toBe(true));
   });
   it('should add 2 items to set', () => {
@@ -16,7 +16,7 @@ describe('sadd', () => {
 
     return redis
       .sadd('foos', 'foo', 'baz')
-      .then(status => expect(status).toBe(2))
+      .then((status) => expect(status).toBe(2))
       .then(() => {
         expect(redis.data.get('foos').has('foo')).toBe(true);
         expect(redis.data.get('foos').has('baz')).toBe(true);
@@ -28,7 +28,7 @@ describe('sadd', () => {
 
     return redis
       .sadd('key', 'value', 'value')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => expect(redis.data.get('key').has('value')).toBe(true));
   });
 });

--- a/test/commands/save.js
+++ b/test/commands/save.js
@@ -6,6 +6,6 @@ describe('save', () => {
   it('should return OK', () => {
     const redis = new MockRedis();
 
-    return redis.save().then(status => expect(status).toBe('OK'));
+    return redis.save().then((status) => expect(status).toBe('OK'));
   });
 });

--- a/test/commands/scan.js
+++ b/test/commands/scan.js
@@ -4,7 +4,7 @@ import MockRedis from '../../src';
 describe('scan', () => {
   it('should return null array if nothing in db', () => {
     const redis = new MockRedis();
-    return redis.scan(0).then(result => {
+    return redis.scan(0).then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual([]);
     });
@@ -18,38 +18,38 @@ describe('scan', () => {
       },
     });
 
-    return redis.scan(0).then(result => {
+    return redis.scan(0).then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo', 'test']);
     });
   });
   it('should return fail if incorrect count', () => {
     const redis = new MockRedis();
-    return redis.scan('asdf').catch(result => {
+    return redis.scan('asdf').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should return fail if incorrect command', () => {
     const redis = new MockRedis();
-    return redis.scan(0, 'ZU').catch(result => {
+    return redis.scan(0, 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should return fail if incorrect MATCH usage', () => {
     const redis = new MockRedis();
-    return redis.scan(0, 'MATCH', 'sadf', 'ZU').catch(result => {
+    return redis.scan(0, 'MATCH', 'sadf', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should return fail if incorrect COUNT usage', () => {
     const redis = new MockRedis();
-    return redis.scan(0, 'COUNT', 10, 'ZU').catch(result => {
+    return redis.scan(0, 'COUNT', 10, 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should return fail if incorrect COUNT usage 2', () => {
     const redis = new MockRedis();
-    return redis.scan(0, 'COUNT', 'adsf').catch(result => {
+    return redis.scan(0, 'COUNT', 'adsf').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
@@ -64,7 +64,7 @@ describe('scan', () => {
       },
     });
 
-    return redis.scan(0, 'MATCH', 'foo*').then(result => {
+    return redis.scan(0, 'MATCH', 'foo*').then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo0', 'foo1', 'foo2']);
     });
@@ -82,12 +82,12 @@ describe('scan', () => {
 
     return redis
       .scan(0, 'MATCH', 'foo*', 'COUNT', 1)
-      .then(result => {
+      .then((result) => {
         expect(result[0]).toBe('1'); // more elements left, this is why cursor is not 0
         expect(result[1]).toEqual(['foo0']);
         return redis.scan(result[0], 'MATCH', 'foo*', 'COUNT', 10);
       })
-      .then(result2 => {
+      .then((result2) => {
         expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['foo1', 'foo2']);
       });
@@ -104,12 +104,12 @@ describe('scan', () => {
 
     return redis
       .scan(0, 'COUNT', 3)
-      .then(result => {
+      .then((result) => {
         expect(result[0]).toBe('3');
         expect(result[1]).toEqual(['foo0', 'foo1', 'test0']);
         return redis.scan(result[0], 'COUNT', 3);
       })
-      .then(result2 => {
+      .then((result2) => {
         expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['test1']);
       });

--- a/test/commands/scanStream.js
+++ b/test/commands/scanStream.js
@@ -8,13 +8,13 @@ const chance = new Chance();
 
 describe('scanStream', () => {
   let writable;
-  const flatten = wrt => _.flatten(wrt.data);
+  const flatten = (wrt) => _.flatten(wrt.data);
 
   beforeEach(() => {
     writable = new ObjectWritableMock();
   });
 
-  it('should return null array if nothing in db', done => {
+  it('should return null array if nothing in db', (done) => {
     // Given
     const redis = new MockRedis();
     const stream = redis.scanStream();
@@ -27,7 +27,7 @@ describe('scanStream', () => {
     });
   });
 
-  it('should return keys in db', done => {
+  it('should return keys in db', (done) => {
     const redis = new MockRedis({
       data: {
         foo: 'bar',
@@ -44,7 +44,7 @@ describe('scanStream', () => {
     });
   });
 
-  it('should batch by count', done => {
+  it('should batch by count', (done) => {
     // Given
     const keys = chance.unique(chance.word, 100);
     const count = 11;
@@ -61,7 +61,7 @@ describe('scanStream', () => {
     });
   });
 
-  it('should return only mathced keys', done => {
+  it('should return only mathced keys', (done) => {
     // Given
     const redis = new MockRedis({
       data: {

--- a/test/commands/scard.js
+++ b/test/commands/scard.js
@@ -11,13 +11,13 @@ describe('scard', () => {
       },
     });
 
-    return redis.scard('foo').then(length => expect(length).toBe(3));
+    return redis.scard('foo').then((length) => expect(length).toBe(3));
   });
 
   it('should return 0 if the set does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.scard('foo').then(length => expect(length).toBe(0));
+    return redis.scard('foo').then((length) => expect(length).toBe(0));
   });
 
   it('should throw an exception if the key contains something other than a set', () => {
@@ -29,6 +29,8 @@ describe('scard', () => {
 
     return redis
       .scard('foo')
-      .catch(err => expect(err.message).toBe('Key foo does not contain a set'));
+      .catch((err) =>
+        expect(err.message).toBe('Key foo does not contain a set')
+      );
   });
 });

--- a/test/commands/sdiff.js
+++ b/test/commands/sdiff.js
@@ -16,7 +16,7 @@ describe('sdiff', () => {
 
     return redis
       .sdiff('key1', 'key2', 'key3', 'key4')
-      .then(result => expect(result).toEqual(['b', 'd']));
+      .then((result) => expect(result).toEqual(['b', 'd']));
   });
 
   it('should throw an exception if the first key is not of a set', () => {
@@ -28,7 +28,9 @@ describe('sdiff', () => {
 
     return redis
       .sdiff('foo', 'bar')
-      .catch(err => expect(err.message).toBe('Key foo does not contain a set'));
+      .catch((err) =>
+        expect(err.message).toBe('Key foo does not contain a set')
+      );
   });
 
   it('should throw an exception if the destination contains something other than a set', () => {
@@ -41,12 +43,16 @@ describe('sdiff', () => {
 
     return redis
       .sdiff('foo', 'bar')
-      .catch(err => expect(err.message).toBe('Key bar does not contain a set'));
+      .catch((err) =>
+        expect(err.message).toBe('Key bar does not contain a set')
+      );
   });
 
   it("should return empty array if sources don't exists", () => {
     const redis = new MockRedis();
 
-    return redis.sdiff('foo', 'bar').then(result => expect(result).toEqual([]));
+    return redis
+      .sdiff('foo', 'bar')
+      .then((result) => expect(result).toEqual([]));
   });
 });

--- a/test/commands/set.js
+++ b/test/commands/set.js
@@ -7,7 +7,7 @@ describe('set', () => {
     const redis = new MockRedis();
     return redis
       .set('foo', 'bar')
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => expect(redis.data.get('foo')).toBe('bar'));
   });
 
@@ -15,7 +15,7 @@ describe('set', () => {
     const redis = new MockRedis();
     return redis
       .set('foo', 1.5)
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => expect(redis.data.get('foo')).toBe('1.5'));
   });
 
@@ -23,7 +23,7 @@ describe('set', () => {
     const redis = new MockRedis();
     return redis
       .set('foo', null)
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => {
         expect(redis.data.get('foo')).toBe('');
       });
@@ -33,7 +33,7 @@ describe('set', () => {
     const redis = new MockRedis();
     return redis
       .set('foo', 'bar', 'EX', 1)
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => {
         expect(redis.data.get('foo')).toBe('bar');
         expect(redis.expires.has('foo')).toBe(true);
@@ -45,13 +45,15 @@ describe('set', () => {
 
     return redis
       .set('foo', 1, 'NX', 'XX')
-      .catch(err => expect(err.message).toBe('ERR syntax error'));
+      .catch((err) => expect(err.message).toBe('ERR syntax error'));
   });
 
   it('should return null if XX is specified and the key does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.set('foo', 1, 'XX').then(result => expect(result).toBe(null));
+    return redis
+      .set('foo', 1, 'XX')
+      .then((result) => expect(result).toBe(null));
   });
 
   it('should return null if NX is specified and the key already exists', () => {
@@ -61,6 +63,8 @@ describe('set', () => {
       },
     });
 
-    return redis.set('foo', 1, 'NX').then(result => expect(result).toBe(null));
+    return redis
+      .set('foo', 1, 'NX')
+      .then((result) => expect(result).toBe(null));
   });
 });

--- a/test/commands/setbit.js
+++ b/test/commands/setbit.js
@@ -9,7 +9,7 @@ describe('getbit', () => {
         foo: '@',
       },
     });
-    return redis.setbit('foo', 1, 0).then(result => expect(result).toBe(1));
+    return redis.setbit('foo', 1, 0).then((result) => expect(result).toBe(1));
   });
 
   it('should padd if offset out of range', () => {
@@ -17,7 +17,7 @@ describe('getbit', () => {
 
     return redis
       .setbit('foo', 9, 1)
-      .then(result => expect(result).toBe(0))
+      .then((result) => expect(result).toBe(0))
       .then(() => expect(redis.data.get('foo')).toBe('\x00@'));
   });
 
@@ -30,7 +30,7 @@ describe('getbit', () => {
 
     return redis
       .setbit('foo', 3, 1)
-      .then(result => expect(result).toBe(0))
+      .then((result) => expect(result).toBe(0))
       .then(() => expect(redis.data.get('foo')).toBe('rar'));
   });
 
@@ -39,7 +39,7 @@ describe('getbit', () => {
 
     return redis
       .setbit('foo', 1, 1)
-      .then(result => expect(result).toBe(0))
+      .then((result) => expect(result).toBe(0))
       .then(() => expect(redis.data.get('foo')).toBe('@'));
   });
 
@@ -50,7 +50,7 @@ describe('getbit', () => {
       () => {
         throw new Error('Expected setbit to fail');
       },
-      err => {
+      (err) => {
         expect(err).toBeA(Error);
         expect(err.message).toBe(
           'ERR bit offset is not an integer or out of range'
@@ -66,7 +66,7 @@ describe('getbit', () => {
       () => {
         throw new Error('Expected setbit to fail');
       },
-      err => {
+      (err) => {
         expect(err).toBeA(Error);
         expect(err.message).toBe('ERR bit is not an integer or out of range');
       }

--- a/test/commands/setex.js
+++ b/test/commands/setex.js
@@ -7,7 +7,7 @@ describe('setex', () => {
     const redis = new MockRedis();
     return redis
       .setex('foo', 1, 'bar')
-      .then(status => expect(status).toBe('OK'))
+      .then((status) => expect(status).toBe('OK'))
       .then(() => {
         expect(redis.data.get('foo')).toBe('bar');
         expect(redis.expires.has('foo')).toBe(true);

--- a/test/commands/setnx.js
+++ b/test/commands/setnx.js
@@ -7,12 +7,12 @@ describe('setnx', () => {
     const redis = new MockRedis();
     return redis
       .setnx('foo', 'bar')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => {
         expect(redis.data.get('foo')).toBe('bar', 'value failed to persist');
         return redis.setnx('foo', 'baz');
       })
-      .then(status =>
+      .then((status) =>
         expect(status).toBe(0, 'setnx no-op failed on existing key')
       )
       .then(() => {

--- a/test/commands/sinter.js
+++ b/test/commands/sinter.js
@@ -15,7 +15,7 @@ describe('sinter', () => {
 
     return redis
       .sinter('key1', 'key2', 'key3')
-      .then(result => expect(result).toEqual(['c']));
+      .then((result) => expect(result).toEqual(['c']));
   });
 
   it('should throw an exception if one of the keys is not a set', () => {
@@ -28,7 +28,9 @@ describe('sinter', () => {
 
     return redis
       .sinter('foo', 'bar')
-      .catch(err => expect(err.message).toBe('Key bar does not contain a set'));
+      .catch((err) =>
+        expect(err.message).toBe('Key bar does not contain a set')
+      );
   });
 
   it("should return empty array if sources don't exists", () => {
@@ -36,6 +38,6 @@ describe('sinter', () => {
 
     return redis
       .sinter('foo', 'bar')
-      .then(result => expect(result).toEqual([]));
+      .then((result) => expect(result).toEqual([]));
   });
 });

--- a/test/commands/sismember.js
+++ b/test/commands/sismember.js
@@ -13,8 +13,8 @@ describe('sismember', () => {
 
     return redis
       .sismember('foos', 'foo')
-      .then(result => expect(result).toBe(1))
+      .then((result) => expect(result).toBe(1))
       .then(() => redis.sismember('foos', 'foobar'))
-      .then(result => expect(result).toBe(0));
+      .then((result) => expect(result).toBe(0));
   });
 });

--- a/test/commands/smembers.js
+++ b/test/commands/smembers.js
@@ -13,11 +13,11 @@ describe('smembers', () => {
 
     return redis
       .smembers('foos')
-      .then(result => expect(result.sort()).toEqual(['bar', 'foo']));
+      .then((result) => expect(result.sort()).toEqual(['bar', 'foo']));
   });
   it("should return empty array if source don't exists", () => {
     const redis = new MockRedis();
 
-    return redis.smembers('bars').then(result => expect(result).toEqual([]));
+    return redis.smembers('bars').then((result) => expect(result).toEqual([]));
   });
 });

--- a/test/commands/smove.js
+++ b/test/commands/smove.js
@@ -13,7 +13,7 @@ describe('smove', () => {
 
     return redis
       .smove('foo', 'bar', 'two')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => {
         expect(redis.data.get('foo').has('two')).toBe(false);
         expect(redis.data.get('bar').has('two')).toBe(true);
@@ -29,7 +29,7 @@ describe('smove', () => {
 
     return redis
       .smove('foo', 'bar', 'two')
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() => expect(redis.data.has('bar')).toBe(false));
   });
 
@@ -38,7 +38,7 @@ describe('smove', () => {
 
     return redis
       .smove('foo', 'bar', 'two')
-      .then(status => expect(status).toBe(0));
+      .then((status) => expect(status).toBe(0));
   });
 
   it('should throw an exception if the source contains something other than a set', () => {
@@ -50,7 +50,9 @@ describe('smove', () => {
 
     return redis
       .smove('foo', 'bar', 'two')
-      .catch(err => expect(err.message).toBe('Key foo does not contain a set'));
+      .catch((err) =>
+        expect(err.message).toBe('Key foo does not contain a set')
+      );
   });
 
   it('should throw an exception if the destination contains something other than a set', () => {
@@ -63,6 +65,8 @@ describe('smove', () => {
 
     return redis
       .smove('foo', 'bar', 'two')
-      .catch(err => expect(err.message).toBe('Key bar does not contain a set'));
+      .catch((err) =>
+        expect(err.message).toBe('Key bar does not contain a set')
+      );
   });
 });

--- a/test/commands/spop.js
+++ b/test/commands/spop.js
@@ -11,7 +11,7 @@ describe('spop', () => {
       },
     });
 
-    return redis.spop('myset').then(result => {
+    return redis.spop('myset').then((result) => {
       expect(result.constructor).toBe(String);
       expect(['one', 'two', 'three']).toInclude(result);
       expect(redis.data.get('myset').size).toBe(2);
@@ -25,7 +25,7 @@ describe('spop', () => {
       },
     });
 
-    return redis.spop('myset').then(result => {
+    return redis.spop('myset').then((result) => {
       expect(result.constructor).toBe(String);
       expect(result).toBe('one');
       expect(redis.data.get('myset').size).toBe(0);
@@ -39,7 +39,7 @@ describe('spop', () => {
       },
     });
 
-    return redis.spop('myset', 2).then(results => {
+    return redis.spop('myset', 2).then((results) => {
       expect(['one', 'two', 'three']).toInclude(results[0]);
       expect(['one', 'two', 'three']).toInclude(results[1]);
       expect(redis.data.get('myset').size).toBe(1);
@@ -53,7 +53,7 @@ describe('spop', () => {
       },
     });
 
-    return redis.spop('myset', 5).then(results => {
+    return redis.spop('myset', 5).then((results) => {
       expect(results).toEqual(['one', 'two', 'three']);
       expect(redis.data.get('myset').size).toBe(0);
     });
@@ -62,7 +62,7 @@ describe('spop', () => {
   it('should return null if set is empty', () => {
     const redis = new MockRedis();
 
-    return redis.spop('myset').then(result => expect(result).toBe(null));
+    return redis.spop('myset').then((result) => expect(result).toBe(null));
   });
 
   it('should return undefined if count is 0', () => {
@@ -74,7 +74,7 @@ describe('spop', () => {
 
     return redis
       .spop('myset', 0)
-      .then(result => expect(result).toBe(undefined));
+      .then((result) => expect(result).toBe(undefined));
   });
 
   it('should throw an exception if the key contains something other than a set', () => {
@@ -86,7 +86,9 @@ describe('spop', () => {
 
     return redis
       .spop('foo')
-      .catch(err => expect(err.message).toBe('Key foo does not contain a set'));
+      .catch((err) =>
+        expect(err.message).toBe('Key foo does not contain a set')
+      );
   });
 
   it('should throw an exception if count is not an integer', () => {
@@ -98,7 +100,7 @@ describe('spop', () => {
 
     return redis
       .spop('myset', 'not an integer')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('ERR value is not an integer or out of range')
       );
   });
@@ -112,7 +114,7 @@ describe('spop', () => {
 
     return redis
       .spop('myset', -10)
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('ERR value is not an integer or out of range')
       );
   });

--- a/test/commands/srandmember.js
+++ b/test/commands/srandmember.js
@@ -13,7 +13,7 @@ describe('srandmember', () => {
 
     return redis
       .srandmember('myset')
-      .then(result => expect(['one', 'two', 'three']).toInclude(result));
+      .then((result) => expect(['one', 'two', 'three']).toInclude(result));
   });
 
   it('should return random unique items', () => {
@@ -23,7 +23,7 @@ describe('srandmember', () => {
       },
     });
 
-    return redis.srandmember('myset', 2).then(results => {
+    return redis.srandmember('myset', 2).then((results) => {
       expect(['one', 'two', 'three']).toInclude(results[0]);
       expect(['one', 'two', 'three']).toInclude(results[1]);
       expect(results[0]).toNotBe(results[1]);
@@ -37,7 +37,7 @@ describe('srandmember', () => {
       },
     });
 
-    return redis.srandmember('myset', 5).then(results => {
+    return redis.srandmember('myset', 5).then((results) => {
       expect(['one', 'two', 'three']).toInclude(results[0]);
       expect(['one', 'two', 'three']).toInclude(results[1]);
       expect(['one', 'two', 'three']).toInclude(results[2]);
@@ -53,13 +53,15 @@ describe('srandmember', () => {
 
     return redis
       .srandmember('myset', -5)
-      .then(results => expect(results.length).toBe(5));
+      .then((results) => expect(results.length).toBe(5));
   });
 
   it('should return null if set is empty', () => {
     const redis = new MockRedis();
 
-    return redis.srandmember('myset').then(result => expect(result).toBe(null));
+    return redis
+      .srandmember('myset')
+      .then((result) => expect(result).toBe(null));
   });
 
   it('should throw an exception if the key contains something other than a set', () => {
@@ -71,6 +73,8 @@ describe('srandmember', () => {
 
     return redis
       .srandmember('foo')
-      .catch(err => expect(err.message).toBe('Key foo does not contain a set'));
+      .catch((err) =>
+        expect(err.message).toBe('Key foo does not contain a set')
+      );
   });
 });

--- a/test/commands/srem.js
+++ b/test/commands/srem.js
@@ -12,16 +12,16 @@ describe('srem', () => {
   it('should remove 1 item from set', () =>
     redis
       .srem('foos', 'bar')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => expect(redis.data.get('foos').has('bar')).toBe(false)));
   it('should remove 2 items from set', () =>
     redis
       .srem('foos', 'foo', 'baz', 'none existent')
-      .then(status => expect(status).toBe(2))
+      .then((status) => expect(status).toBe(2))
       .then(() => {
         expect(redis.data.get('foos').has('bar')).toBe(false);
         expect(redis.data.get('foos').has('baz')).toBe(false);
       }));
   it("should return 0 if source don't exists", () =>
-    redis.srem('bars', 'foo').then(status => expect(status).toBe(0)));
+    redis.srem('bars', 'foo').then((status) => expect(status).toBe(0)));
 });

--- a/test/commands/sscan.js
+++ b/test/commands/sscan.js
@@ -5,7 +5,7 @@ import MockRedis from '../../src';
 describe('sscan', () => {
   it('should return null array if set does not exist', () => {
     const redis = new MockRedis();
-    return redis.sscan('key', 0).then(result => {
+    return redis.sscan('key', 0).then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual([]);
     });
@@ -18,7 +18,7 @@ describe('sscan', () => {
       },
     });
 
-    return redis.sscan('set', 0).then(result => {
+    return redis.sscan('set', 0).then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo', 'bar', 'baz']);
     });
@@ -31,7 +31,7 @@ describe('sscan', () => {
       },
     });
 
-    return redis.sscan('set', 0, 'MATCH', 'foo*').then(result => {
+    return redis.sscan('set', 0, 'MATCH', 'foo*').then((result) => {
       expect(result[0]).toBe('0');
       expect(result[1]).toEqual(['foo0', 'foo1', 'foo2']);
     });
@@ -46,12 +46,12 @@ describe('sscan', () => {
 
     return redis
       .sscan('set', 0, 'MATCH', 'foo*', 'COUNT', 1)
-      .then(result => {
+      .then((result) => {
         expect(result[0]).toBe('1'); // more elements left, this is why cursor is not 0
         expect(result[1]).toEqual(['foo0']);
         return redis.sscan('set', result[0], 'MATCH', 'foo*', 'COUNT', 10);
       })
-      .then(result2 => {
+      .then((result2) => {
         expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['foo1', 'foo2']);
       });
@@ -66,12 +66,12 @@ describe('sscan', () => {
 
     return redis
       .sscan('set', 0, 'COUNT', 3)
-      .then(result => {
+      .then((result) => {
         expect(result[0]).toBe('3');
         expect(result[1]).toEqual(['foo0', 'foo1', 'bar0']);
         return redis.sscan('set', result[0], 'COUNT', 3);
       })
-      .then(result2 => {
+      .then((result2) => {
         expect(result2[0]).toBe('0');
         expect(result2[1]).toEqual(['bar1']);
       });
@@ -79,31 +79,31 @@ describe('sscan', () => {
 
   it('should fail if incorrect cursor', () => {
     const redis = new MockRedis();
-    return redis.sscan('key', 'ZU').catch(result => {
+    return redis.sscan('key', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect command', () => {
     const redis = new MockRedis();
-    return redis.sscan('key', 0, 'ZU').catch(result => {
+    return redis.sscan('key', 0, 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect MATCH usage', () => {
     const redis = new MockRedis();
-    return redis.sscan('key', 0, 'MATCH', 'pattern', 'ZU').catch(result => {
+    return redis.sscan('key', 0, 'MATCH', 'pattern', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect COUNT usage', () => {
     const redis = new MockRedis();
-    return redis.sscan('key', 0, 'COUNT', 10, 'ZU').catch(result => {
+    return redis.sscan('key', 0, 'COUNT', 10, 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
   it('should fail if incorrect COUNT usage 2', () => {
     const redis = new MockRedis();
-    return redis.sscan('key', 0, 'COUNT', 'ZU').catch(result => {
+    return redis.sscan('key', 0, 'COUNT', 'ZU').catch((result) => {
       expect(result).toBeA(Error);
     });
   });
@@ -111,7 +111,7 @@ describe('sscan', () => {
     const redis = new MockRedis();
     return redis
       .sscan('key', 0, 'MATCH', 'foo*', 'COUNT', 1, 'ZU')
-      .catch(result => {
+      .catch((result) => {
         expect(result).toBeA(Error);
         expect(result.message).toEqual('Too many arguments');
       });
@@ -119,7 +119,7 @@ describe('sscan', () => {
 
   it('should fail if arguments length not odd', () => {
     const redis = new MockRedis();
-    return redis.sscan('key', 0, 'MATCH', 'foo*', 'COUNT').catch(result => {
+    return redis.sscan('key', 0, 'MATCH', 'foo*', 'COUNT').catch((result) => {
       expect(result).toBeA(Error);
       expect(result.message).toEqual(
         'Args should be provided by pair (name & value)'

--- a/test/commands/sscanStream.js
+++ b/test/commands/sscanStream.js
@@ -9,13 +9,13 @@ const chance = new Chance();
 
 describe('sscanStream', () => {
   let writable;
-  const flatten = wrt => _.flatten(wrt.data);
+  const flatten = (wrt) => _.flatten(wrt.data);
 
   beforeEach(() => {
     writable = new ObjectWritableMock();
   });
 
-  it('should return null array if nothing in db', done => {
+  it('should return null array if nothing in db', (done) => {
     // Given
     const redis = new MockRedis();
     const stream = redis.sscanStream('key');
@@ -28,7 +28,7 @@ describe('sscanStream', () => {
     });
   });
 
-  it('should return keys in db', done => {
+  it('should return keys in db', (done) => {
     const redis = new MockRedis({
       data: {
         set: new Set(['foo', 'bar']),
@@ -44,7 +44,7 @@ describe('sscanStream', () => {
     });
   });
 
-  it('should batch by count', done => {
+  it('should batch by count', (done) => {
     // Given
     const keys = chance.unique(chance.word, 100);
     const count = 11;
@@ -60,7 +60,7 @@ describe('sscanStream', () => {
     });
   });
 
-  it('should return only mathced keys', done => {
+  it('should return only mathced keys', (done) => {
     // Given
     const redis = new MockRedis({
       data: {
@@ -77,7 +77,7 @@ describe('sscanStream', () => {
     });
   });
 
-  it('should return only mathced keys by count', done => {
+  it('should return only mathced keys by count', (done) => {
     // Given
     const redis = new MockRedis({
       data: {
@@ -95,7 +95,7 @@ describe('sscanStream', () => {
     });
   });
 
-  it('should fail if incorrect count usage', done => {
+  it('should fail if incorrect count usage', (done) => {
     // Given
     const redis = new MockRedis({
       data: {
@@ -105,7 +105,7 @@ describe('sscanStream', () => {
     const stream = redis.sscanStream('set', { count: 'ZU' });
     // When
     stream.pipe(writable);
-    stream.on('error', err => {
+    stream.on('error', (err) => {
       // Then
       expect(err).toBeA(Error);
       done();

--- a/test/commands/strlen.js
+++ b/test/commands/strlen.js
@@ -6,7 +6,7 @@ describe('strlen', () => {
   it('should return 0 on keys that do not exist', () => {
     const redis = new MockRedis();
 
-    return redis.strlen('nonexisting').then(result => expect(result).toBe(0));
+    return redis.strlen('nonexisting').then((result) => expect(result).toBe(0));
   });
 
   it('should return string length of keys that do exist', () => {
@@ -16,6 +16,6 @@ describe('strlen', () => {
       },
     });
 
-    return redis.strlen('mykey').then(result => expect(result).toBe(11));
+    return redis.strlen('mykey').then((result) => expect(result).toBe(11));
   });
 });

--- a/test/commands/subscribe.js
+++ b/test/commands/subscribe.js
@@ -5,23 +5,23 @@ import MockRedis from '../../src';
 describe('subscribe', () => {
   it('should ignore an empty subscribe call', () => {
     const redis = new MockRedis();
-    return redis.subscribe().then(subNum => expect(subNum).toBe(0));
+    return redis.subscribe().then((subNum) => expect(subNum).toBe(0));
   });
 
   it('should return number of subscribed channels', () => {
     const redis = new MockRedis();
     return redis
       .subscribe('news', 'music')
-      .then(subNum => expect(subNum).toBe(2));
+      .then((subNum) => expect(subNum).toBe(2));
   });
 
   it('should return number of subscribed channels when calling subscribe twice', () => {
     const redis = new MockRedis();
     return redis
       .subscribe('first')
-      .then(subNum => expect(subNum).toBe(1))
+      .then((subNum) => expect(subNum).toBe(1))
       .then(() =>
-        redis.subscribe('second').then(subNum => expect(subNum).toBe(2))
+        redis.subscribe('second').then((subNum) => expect(subNum).toBe(2))
       );
   });
 
@@ -29,9 +29,9 @@ describe('subscribe', () => {
     const redis = new MockRedis();
     return redis
       .subscribe('channel')
-      .then(subNum => expect(subNum).toBe(1))
+      .then((subNum) => expect(subNum).toBe(1))
       .then(() =>
-        redis.subscribe('channel').then(subNum => expect(subNum).toBe(1))
+        redis.subscribe('channel').then((subNum) => expect(subNum).toBe(1))
       );
   });
 
@@ -43,7 +43,7 @@ describe('subscribe', () => {
         .then(() => {
           throw new Error('get should fail when in subscriber mode');
         })
-        .catch(error =>
+        .catch((error) =>
           expect(error.message).toBe(
             'Connection in subscriber mode, only subscriber commands may be used'
           )
@@ -63,10 +63,10 @@ describe('subscribe', () => {
       expect(twoResult).toEqual(1);
       let promiseOneFulfill;
       let PromiseTwoFulfill;
-      const promiseOne = new Promise(f => {
+      const promiseOne = new Promise((f) => {
         promiseOneFulfill = f;
       });
-      const promiseTwo = new Promise(f => {
+      const promiseTwo = new Promise((f) => {
         PromiseTwoFulfill = f;
       });
 

--- a/test/commands/sunion.js
+++ b/test/commands/sunion.js
@@ -16,7 +16,7 @@ describe('sunion', () => {
 
     return redis
       .sunion('key1', 'key2', 'key3', 'key4')
-      .then(result => expect(result).toEqual(['a', 'b', 'c', 'd', 'e']));
+      .then((result) => expect(result).toEqual(['a', 'b', 'c', 'd', 'e']));
   });
 
   it('should throw an exception if one of the keys is not a set', () => {
@@ -29,6 +29,8 @@ describe('sunion', () => {
 
     return redis
       .sunion('foo', 'bar')
-      .catch(err => expect(err.message).toBe('Key bar does not contain a set'));
+      .catch((err) =>
+        expect(err.message).toBe('Key bar does not contain a set')
+      );
   });
 });

--- a/test/commands/time.js
+++ b/test/commands/time.js
@@ -7,7 +7,7 @@ describe('time', () => {
     const redis = new MockRedis();
     const time = Math.round(new Date().getTime() / 1000);
 
-    return redis.time().then(result => {
+    return redis.time().then((result) => {
       expect(result[0]).toBeGreaterThanOrEqualTo(time);
       expect(result[0]).toBeLessThan(time + 10);
       expect(result[1]).toBeA('number');

--- a/test/commands/ttl.js
+++ b/test/commands/ttl.js
@@ -6,7 +6,7 @@ describe('ttl', () => {
   it('should return -2 if key does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.ttl('foo').then(result => expect(result).toBe(-2));
+    return redis.ttl('foo').then((result) => expect(result).toBe(-2));
   });
 
   it('should return -1 if key exist but have no expire', () => {
@@ -16,7 +16,7 @@ describe('ttl', () => {
       },
     });
 
-    return redis.ttl('foo').then(result => expect(result).toBe(-1));
+    return redis.ttl('foo').then((result) => expect(result).toBe(-1));
   });
 
   it('should return seconds left until expire', () => {
@@ -29,6 +29,6 @@ describe('ttl', () => {
     return redis
       .expire('foo', 1)
       .then(() => redis.ttl('foo'))
-      .then(result => expect(result).toBe(1));
+      .then((result) => expect(result).toBe(1));
   });
 });

--- a/test/commands/type.js
+++ b/test/commands/type.js
@@ -6,31 +6,31 @@ describe('type', () => {
   const redis = new MockRedis();
 
   it('should return none when key does not exist', () =>
-    redis.type('nope').then(type => expect(type).toBe('none')));
+    redis.type('nope').then((type) => expect(type).toBe('none')));
 
   it('should return string', () =>
     redis
       .set('mystring', 'foo')
       .then(() => redis.type('mystring'))
-      .then(type => expect(type).toBe('string')));
+      .then((type) => expect(type).toBe('string')));
 
   it('should return list', () =>
     redis
       .lpush('mylist', 'foo')
       .then(() => redis.type('mylist'))
-      .then(type => expect(type).toBe('list')));
+      .then((type) => expect(type).toBe('list')));
 
   it('should return set', () =>
     redis
       .sadd('myset', 'foo')
       .then(() => redis.type('myset'))
-      .then(type => expect(type).toBe('set')));
+      .then((type) => expect(type).toBe('set')));
 
   it('should return hash', () =>
     redis
       .hset('myhash', 'foo', 'bar')
       .then(() => redis.type('myhash'))
-      .then(type => expect(type).toBe('hash')));
+      .then((type) => expect(type).toBe('hash')));
 
   it('should return zset');
 });

--- a/test/commands/unlink.js
+++ b/test/commands/unlink.js
@@ -12,9 +12,9 @@ describe('unlink', () => {
   it('should unlink/delete passed in keys', () =>
     redis
       .unlink('unlinkme', 'metoo')
-      .then(status => expect(status).toBe(2))
+      .then((status) => expect(status).toBe(2))
       .then(() => expect(redis.data.has('unlinkme')).toBe(false))
       .then(() => expect(redis.data.has('metoo')).toBe(false)));
   it('should return the number of keys unlinked', () =>
-    redis.unlink('deleteme', 'metoo').then(status => expect(status).toBe(0)));
+    redis.unlink('deleteme', 'metoo').then((status) => expect(status).toBe(0)));
 });

--- a/test/commands/unsubscribe.js
+++ b/test/commands/unsubscribe.js
@@ -7,26 +7,26 @@ describe('unsubscribe', () => {
     const redis = new MockRedis();
     // unsubscribe returns the number of open channels (like subscribe)
     // unsubscribe() should always return 0, as we have unsubscribed from all channels
-    return redis.unsubscribe().then(subNum => expect(subNum).toBe(0));
+    return redis.unsubscribe().then((subNum) => expect(subNum).toBe(0));
   });
 
   it('should return 0 when no arguments are given after being subscribed to a channel', () => {
     const redis = new MockRedis();
     return redis
       .subscribe('first')
-      .then(subNum => expect(subNum).toBe(1))
-      .then(() => redis.unsubscribe().then(subNum => expect(subNum).toBe(0)));
+      .then((subNum) => expect(subNum).toBe(1))
+      .then(() => redis.unsubscribe().then((subNum) => expect(subNum).toBe(0)));
   });
 
   it('should return the number of subscribed channels when unsubscribing from a subscribed channel', () => {
     const redis = new MockRedis();
     return redis
       .subscribe('first', 'second', 'third')
-      .then(subNum => expect(subNum).toBe(3))
+      .then((subNum) => expect(subNum).toBe(3))
       .then(() =>
         redis
           .unsubscribe('second', 'third')
-          .then(subNum => expect(subNum).toBe(1))
+          .then((subNum) => expect(subNum).toBe(1))
       );
   });
 
@@ -37,7 +37,7 @@ describe('unsubscribe', () => {
       .then(() => {
         return redis.unsubscribe('second');
       })
-      .then(subNum => expect(subNum).toBe(1));
+      .then((subNum) => expect(subNum).toBe(1));
   });
 
   it('should unsubscribe only one instance when more than one is subscribed to a channel', () => {
@@ -51,11 +51,11 @@ describe('unsubscribe', () => {
       .then(() => {
         return redisTwo.unsubscribe('first');
       })
-      .then(result => {
+      .then((result) => {
         expect(result).toEqual(1);
 
         let promiseFulfill;
-        const promise = new Promise(f => {
+        const promise = new Promise((f) => {
           promiseFulfill = f;
         });
 
@@ -75,11 +75,11 @@ describe('unsubscribe', () => {
       .then(() => {
         return redisTwo.unsubscribe('first');
       })
-      .then(subNum => {
+      .then((subNum) => {
         expect(subNum).toBe(0);
         return redisTwo.publish('first', '');
       })
-      .then(subNum => {
+      .then((subNum) => {
         expect(subNum).toBe(1);
       });
   });

--- a/test/commands/xadd.js
+++ b/test/commands/xadd.js
@@ -7,7 +7,7 @@ describe('xadd', () => {
     const redis = new MockRedis();
     return redis
       .xadd('stream', '*', 'key', 'val')
-      .then(id => {
+      .then((id) => {
         expect(id).toBe('1-0');
         expect(redis.data.get('stream')).toEqual([['1-0', ['key', 'val']]]);
         expect(redis.data.get(`stream:stream:${id}`)).toEqual({
@@ -15,7 +15,7 @@ describe('xadd', () => {
         });
       })
       .then(() => redis.xadd('stream', '*', 'key', 'val'))
-      .then(id => {
+      .then((id) => {
         expect(id).toBe('2-0');
         expect(redis.data.get('stream')).toEqual([
           ['1-0', ['key', 'val']],
@@ -30,12 +30,12 @@ describe('xadd', () => {
   it('should throw with an illegal amount of arguments', () => {
     const redis = new MockRedis();
     return Promise.all([
-      redis.xadd().catch(err => err.message),
-      redis.xadd('stream').catch(err => err.message),
-      redis.xadd('stream', '*').catch(err => err.message),
-      redis.xadd('stream', '*', 'one').catch(err => err.message),
-    ]).then(errors =>
-      errors.forEach(err =>
+      redis.xadd().catch((err) => err.message),
+      redis.xadd('stream').catch((err) => err.message),
+      redis.xadd('stream', '*').catch((err) => err.message),
+      redis.xadd('stream', '*', 'one').catch((err) => err.message),
+    ]).then((errors) =>
+      errors.forEach((err) =>
         expect(err).toBe("ERR wrong number of arguments for 'xadd' command")
       )
     );
@@ -45,8 +45,8 @@ describe('xadd', () => {
     const redis = new MockRedis();
     redis
       .xadd('stream', '*', 'key', 'value')
-      .then(id => redis.xadd('stream', id, 'key', 'value'))
-      .catch(err =>
+      .then((id) => redis.xadd('stream', id, 'key', 'value'))
+      .catch((err) =>
         expect(err.message).toBe(
           'ERR The ID specified in XADD is equal or smaller than the target stream top item'
         )

--- a/test/commands/xlen.js
+++ b/test/commands/xlen.js
@@ -13,11 +13,11 @@ describe('xlen', () => {
         ],
       },
     });
-    return redis.xlen('stream').then(len => expect(len).toBe(3));
+    return redis.xlen('stream').then((len) => expect(len).toBe(3));
   });
 
   it('should return 0 for a non existing stream', () => {
     const redis = new MockRedis();
-    return redis.xlen('non-existing').then(len => expect(len).toBe(0));
+    return redis.xlen('non-existing').then((len) => expect(len).toBe(0));
   });
 });

--- a/test/commands/xrange.js
+++ b/test/commands/xrange.js
@@ -7,7 +7,7 @@ describe('xrange', () => {
     const redis = new MockRedis();
     return redis
       .xrange('non-existing', '-', '+')
-      .then(events => expect(events).toEqual([]));
+      .then((events) => expect(events).toEqual([]));
   });
 
   it('returns the contents of the stream', () => {
@@ -68,7 +68,7 @@ describe('xrange', () => {
         'stream:stream:3-0': { polled: false },
       },
     });
-    return redis.xrange('stream', '-', '+', 'COUNT', '2').then(events => {
+    return redis.xrange('stream', '-', '+', 'COUNT', '2').then((events) => {
       expect(events).toEqual([
         ['1-0', ['key', 'val']],
         ['2-0', ['key', 'val']],
@@ -79,11 +79,11 @@ describe('xrange', () => {
   it('should throw with a wrong number of arguments', () => {
     const redis = new MockRedis();
     Promise.all([
-      redis.xrange('stream', '-').catch(err => err.message),
-      redis.xrange('stream').catch(err => err.message),
-      redis.xrange().catch(err => err.message),
-    ]).then(errors =>
-      errors.forEach(err =>
+      redis.xrange('stream', '-').catch((err) => err.message),
+      redis.xrange('stream').catch((err) => err.message),
+      redis.xrange().catch((err) => err.message),
+    ]).then((errors) =>
+      errors.forEach((err) =>
         expect(err).toBe("ERR wrong number of arguments for 'xrange' command")
       )
     );
@@ -93,6 +93,6 @@ describe('xrange', () => {
     const redis = new MockRedis();
     redis
       .xrange('stream', '-', '+', 'COUNT')
-      .catch(err => expect(err.message).toBe('ERR syntax error'));
+      .catch((err) => expect(err.message).toBe('ERR syntax error'));
   });
 });

--- a/test/commands/xread.js
+++ b/test/commands/xread.js
@@ -20,9 +20,15 @@ describe('xread', () => {
     });
     return redis
       .xread('COUNT', '2', 'STREAMS', 'stream', '2-0')
-      .then(events =>
+      .then((events) =>
         expect(events).toEqual([
-          ['stream', [['2-0', ['key', 'val']], ['3-0', ['key', 'val']]]],
+          [
+            'stream',
+            [
+              ['2-0', ['key', 'val']],
+              ['3-0', ['key', 'val']],
+            ],
+          ],
         ])
       );
   });
@@ -44,9 +50,15 @@ describe('xread', () => {
     });
     return redis
       .xread('COUNT', '2', 'STREAMS', 'stream', '1-0', 'other-stream', '1-0')
-      .then(events =>
+      .then((events) =>
         expect(events).toEqual([
-          ['stream', [['1-0', ['key', 'val']], ['2-0', ['key', 'val']]]],
+          [
+            'stream',
+            [
+              ['1-0', ['key', 'val']],
+              ['2-0', ['key', 'val']],
+            ],
+          ],
           ['other-stream', [['1-0', ['key', 'val']]]],
         ])
       );
@@ -69,9 +81,15 @@ describe('xread', () => {
     });
     return redis
       .xread('COUNT', '2', 'STREAMS', 'stream', '1', 'other-stream', '1')
-      .then(events =>
+      .then((events) =>
         expect(events).toEqual([
-          ['stream', [['1-0', ['key', 'val']], ['2-0', ['key', 'val']]]],
+          [
+            'stream',
+            [
+              ['1-0', ['key', 'val']],
+              ['2-0', ['key', 'val']],
+            ],
+          ],
           ['other-stream', [['1-0', ['key', 'val']]]],
         ])
       );
@@ -79,12 +97,14 @@ describe('xread', () => {
 
   it('should block reads till data becomes available', () => {
     const redis = new MockRedis();
-    const op = redis.xread('BLOCK', '0', 'STREAMS', 'stream', '$').then(row => {
-      const [[stream, [[id, values]]]] = row;
-      expect(stream).toBe('stream');
-      expect(id).toBe('1-0');
-      expect(values).toEqual(['key', 'val']);
-    });
+    const op = redis
+      .xread('BLOCK', '0', 'STREAMS', 'stream', '$')
+      .then((row) => {
+        const [[stream, [[id, values]]]] = row;
+        expect(stream).toBe('stream');
+        expect(id).toBe('1-0');
+        expect(values).toEqual(['key', 'val']);
+      });
     return redis.xadd('stream', '*', 'key', 'val').then(() => op);
   });
 
@@ -92,7 +112,7 @@ describe('xread', () => {
     const redis = new MockRedis();
     const op = redis
       .xread('BLOCK', '0', 'STREAMS', 'stream', '2-0')
-      .then(row => {
+      .then((row) => {
         const [[stream, [[id, values]]]] = row;
         expect(stream).toBe('stream');
         expect(id).toBe('2-0');
@@ -106,7 +126,7 @@ describe('xread', () => {
 
   it('should block reads with a time out', () => {
     const redis = new MockRedis();
-    return redis.xread('BLOCK', '500', 'STREAMS', 'stream', '$').then(row => {
+    return redis.xread('BLOCK', '500', 'STREAMS', 'stream', '$').then((row) => {
       expect(row).toBe(null);
     });
   });
@@ -124,27 +144,31 @@ describe('xread', () => {
         'stream:stream:3-0': { polled: false },
       },
     });
-    return redis
-      .xread('STREAMS', 'stream', '2-0')
-      .then(events =>
-        expect(events).toEqual([
-          ['stream', [['2-0', ['key', 'val']], ['3-0', ['key', 'val']]]],
-        ])
-      );
+    return redis.xread('STREAMS', 'stream', '2-0').then((events) =>
+      expect(events).toEqual([
+        [
+          'stream',
+          [
+            ['2-0', ['key', 'val']],
+            ['3-0', ['key', 'val']],
+          ],
+        ],
+      ])
+    );
   });
 
   it('throws if the operation is neither BLOCK or COUNT', () => {
     const redis = new MockRedis();
     return redis
       .xread('INVALID', '2', 'STREAMS', 'stream', '$')
-      .catch(err => expect(err.message).toBe('ERR syntax error'));
+      .catch((err) => expect(err.message).toBe('ERR syntax error'));
   });
 
   it('throws and error on unabalanced stream/id list', () => {
     const redis = new MockRedis();
     return redis
       .xread('BLOCK', '0', 'STREAMS', 'stream', 'other-stream', '$')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe(
           "ERR Unbalanced XREAD list of streams: for each stream key an ID or '$' must be specified."
         )

--- a/test/commands/xrevrange.js
+++ b/test/commands/xrevrange.js
@@ -7,7 +7,7 @@ describe('xrevrange', () => {
     const redis = new MockRedis();
     return redis
       .xrevrange('non-existing', '-', '+')
-      .then(events => expect(events).toEqual([]));
+      .then((events) => expect(events).toEqual([]));
   });
 
   it('returns the contents of the stream', () => {
@@ -68,7 +68,7 @@ describe('xrevrange', () => {
         'stream:stream:3-0': { polled: false },
       },
     });
-    return redis.xrevrange('stream', '+', '-', 'COUNT', '2').then(events => {
+    return redis.xrevrange('stream', '+', '-', 'COUNT', '2').then((events) => {
       expect(events).toEqual([
         ['3-0', ['key', 'val']],
         ['2-0', ['key', 'val']],
@@ -79,11 +79,11 @@ describe('xrevrange', () => {
   it('should throw with a wrong number of arguments', () => {
     const redis = new MockRedis();
     return Promise.all([
-      redis.xrevrange('stream', '+').catch(err => err.message),
-      redis.xrevrange('stream').catch(err => err.message),
-      redis.xrevrange().catch(err => err.message),
-    ]).then(errors =>
-      errors.forEach(err =>
+      redis.xrevrange('stream', '+').catch((err) => err.message),
+      redis.xrevrange('stream').catch((err) => err.message),
+      redis.xrevrange().catch((err) => err.message),
+    ]).then((errors) =>
+      errors.forEach((err) =>
         expect(err).toBe(
           "ERR wrong number of arguments for 'xrevrange' command"
         )
@@ -95,6 +95,6 @@ describe('xrevrange', () => {
     const redis = new MockRedis();
     return redis
       .xrevrange('stream', '+', '-', 'COUNT')
-      .catch(err => expect(err.message).toBe('ERR syntax error'));
+      .catch((err) => expect(err.message).toBe('ERR syntax error'));
   });
 });

--- a/test/commands/zadd.js
+++ b/test/commands/zadd.js
@@ -8,7 +8,7 @@ describe('zadd', () => {
 
     return redis
       .zadd('foos', '1', 'foo')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => expect(redis.data.get('foos').has('foo')).toBe(true));
   });
   it('should add 2 items to sorted set', () => {
@@ -16,7 +16,7 @@ describe('zadd', () => {
 
     return redis
       .zadd('foos', '1', 'foo', '2', 'baz')
-      .then(status => expect(status).toBe(2))
+      .then((status) => expect(status).toBe(2))
       .then(() => {
         expect(redis.data.get('foos').has('foo')).toBe(true);
         expect(redis.data.get('foos').has('baz')).toBe(true);
@@ -28,7 +28,7 @@ describe('zadd', () => {
 
     return redis
       .zadd('key', 'value', 'value')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => expect(redis.data.get('key').has('value')).toBe(true));
   });
   it('should not allow nx and xx options in the same call', () => {
@@ -36,7 +36,7 @@ describe('zadd', () => {
 
     return redis
       .zadd('key', ['NX', 'XX'], 1, 'value')
-      .catch(e =>
+      .catch((e) =>
         expect(e.message).toEqual(
           'XX and NX options at the same time are not compatible'
         )
@@ -46,7 +46,7 @@ describe('zadd', () => {
     const redis = new MockRedis();
 
     redis.zadd('key', 'NX', 1, 'value').then(() => {
-      redis.zadd('key', 'NX', 2, 'value').then(r => expect(r).toBe(0));
+      redis.zadd('key', 'NX', 2, 'value').then((r) => expect(r).toBe(0));
     });
   });
   it('should return updated + added with CH option', () => {
@@ -55,14 +55,16 @@ describe('zadd', () => {
     redis.zadd('key', 1, 'value').then(() => {
       redis
         .zadd('key', 'CH', 3, 'value', 2, 'value2')
-        .then(r => expect(r).toBe(2));
+        .then((r) => expect(r).toBe(2));
     });
   });
   it('should only update elements that already exist with XX option', () => {
     const redis = new MockRedis();
 
     redis.zadd('key', 1, 'value').then(() => {
-      redis.zadd('key', ['XX', 'CH'], 2, 'value').then(r => expect(r).toBe(1));
+      redis
+        .zadd('key', ['XX', 'CH'], 2, 'value')
+        .then((r) => expect(r).toBe(1));
     });
   });
   it('should handle INCR option', () => {

--- a/test/commands/zcard.js
+++ b/test/commands/zcard.js
@@ -7,17 +7,21 @@ describe('zcard', () => {
   it('should return the number of items in the sorted set', () => {
     const redis = new MockRedis({
       data: {
-        foo: new Map([[1, 'one'], [3, 'three'], [4, 'four']]),
+        foo: new Map([
+          [1, 'one'],
+          [3, 'three'],
+          [4, 'four'],
+        ]),
       },
     });
 
-    return redis.zcard('foo').then(length => expect(length).toBe(3));
+    return redis.zcard('foo').then((length) => expect(length).toBe(3));
   });
 
   it('should return 0 if the sorted set does not exist', () => {
     const redis = new MockRedis();
 
-    return redis.zcard('foo').then(length => expect(length).toBe(0));
+    return redis.zcard('foo').then((length) => expect(length).toBe(0));
   });
 
   it('should throw an exception if the key contains something other than a sorted set', () => {
@@ -29,7 +33,7 @@ describe('zcard', () => {
 
     return redis
       .zcard('foo')
-      .catch(err =>
+      .catch((err) =>
         expect(err.message).toBe('Key foo does not contain a sorted set')
       );
   });

--- a/test/commands/zcount.js
+++ b/test/commands/zcount.js
@@ -16,13 +16,13 @@ describe('zcount', () => {
   it('should return using not strict compare', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zcount('foo', 1, 3).then(res => expect(res).toEqual(3));
+    return redis.zcount('foo', 1, 3).then((res) => expect(res).toEqual(3));
   });
 
   it('should return using strict compare', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zcount('foo', '(3', 5).then(res => expect(res).toEqual(2));
+    return redis.zcount('foo', '(3', 5).then((res) => expect(res).toEqual(2));
   });
 
   it('should accept infinity string', () => {
@@ -30,19 +30,19 @@ describe('zcount', () => {
 
     return redis
       .zcount('foo', '-inf', '+inf')
-      .then(res => expect(res).toEqual(5));
+      .then((res) => expect(res).toEqual(5));
   });
 
   it('should return 0 if out-of-range', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zcount('foo', 10, 100).then(res => expect(res).toEqual(0));
+    return redis.zcount('foo', 10, 100).then((res) => expect(res).toEqual(0));
   });
 
   it('should return 0 if key not found', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zcount('boo', 10, 100).then(res => expect(res).toEqual(0));
+    return redis.zcount('boo', 10, 100).then((res) => expect(res).toEqual(0));
   });
 
   it('should return 0 if the key contains something other than a list', () => {
@@ -52,6 +52,6 @@ describe('zcount', () => {
       },
     });
 
-    return redis.zcount('foo', 1, 2).then(res => expect(res).toEqual(0));
+    return redis.zcount('foo', 1, 2).then((res) => expect(res).toEqual(0));
   });
 });

--- a/test/commands/zincrby.js
+++ b/test/commands/zincrby.js
@@ -14,7 +14,7 @@ describe('zincrby', () => {
     const redis = new MockRedis({ data });
     return redis
       .zincrby('foos', 10, 'foo')
-      .then(status => expect(status).toBe('11'))
+      .then((status) => expect(status).toBe('11'))
       .then(() =>
         expect(redis.data.get('foos').get('foo')).toEqual({
           value: 'foo',
@@ -26,7 +26,7 @@ describe('zincrby', () => {
     const redis = new MockRedis({ data });
     return redis
       .zincrby('foos', 4, 'qux')
-      .then(status => expect(status).toBe('4'))
+      .then((status) => expect(status).toBe('4'))
       .then(() => {
         expect(redis.data.get('foos').get('qux')).toEqual({
           value: 'qux',

--- a/test/commands/zinterstore.js
+++ b/test/commands/zinterstore.js
@@ -30,7 +30,7 @@ describe('zinterstore', () => {
 
     return redis
       .zinterstore('dest', 2, 'foo', 'bar')
-      .then(res => expect(res).toEqual(3));
+      .then((res) => expect(res).toEqual(3));
   });
 
   it('should return 0 if the intersection is an empty set', () => {
@@ -38,7 +38,7 @@ describe('zinterstore', () => {
 
     return redis
       .zinterstore('dest', 2, 'foo', 'baz')
-      .then(res => expect(res).toEqual(0));
+      .then((res) => expect(res).toEqual(0));
   });
 
   it('should not create a sorted set if the intersection is an empty set', () => {
@@ -68,7 +68,7 @@ describe('zinterstore', () => {
 
     return redis
       .zinterstore('dest', 2, 'foo', 'bar', 'baz')
-      .catch(err => expect(err.message).toBe('ERR syntax error'));
+      .catch((err) => expect(err.message).toBe('ERR syntax error'));
   });
 
   it('should throw a syntax error if fewer keys specified than numKeys', () => {
@@ -76,7 +76,7 @@ describe('zinterstore', () => {
 
     return redis
       .zinterstore('dest', 3, 'foo', 'bar')
-      .catch(err => expect(err.message).toBe('ERR syntax error'));
+      .catch((err) => expect(err.message).toBe('ERR syntax error'));
   });
 
   it('should return 0 if one of the keys does not exist', () => {
@@ -84,7 +84,7 @@ describe('zinterstore', () => {
 
     return redis
       .zinterstore('dest', 2, 'foo', 'doesnotexist')
-      .then(res => expect(res).toEqual(0));
+      .then((res) => expect(res).toEqual(0));
   });
 
   it('should return 0 if one of the keys is not a sorted set', () => {
@@ -92,6 +92,6 @@ describe('zinterstore', () => {
 
     return redis
       .zinterstore('dest', 2, 'foo', 'key')
-      .then(res => expect(res).toEqual(0));
+      .then((res) => expect(res).toEqual(0));
   });
 });

--- a/test/commands/zpopmax.js
+++ b/test/commands/zpopmax.js
@@ -16,7 +16,9 @@ describe('zpopmax', () => {
   it('should return first item with score', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zpopmax('foo').then(res => expect(res).toEqual(['fifth', 5]));
+    return redis
+      .zpopmax('foo')
+      .then((res) => expect(res).toEqual(['fifth', 5]));
   });
 
   it('should return first N item with score if count=N', () => {
@@ -24,13 +26,15 @@ describe('zpopmax', () => {
 
     return redis
       .zpopmax('foo', 3)
-      .then(res => expect(res).toEqual(['fifth', 5, 'fourth', 4, 'third', 3]));
+      .then((res) =>
+        expect(res).toEqual(['fifth', 5, 'fourth', 4, 'third', 3])
+      );
   });
 
   it('should return empty list if no data', () => {
     const redis = new MockRedis({ data: {} });
 
-    return redis.zpopmax('foo').then(res => expect(res).toEqual([]));
+    return redis.zpopmax('foo').then((res) => expect(res).toEqual([]));
   });
 
   it('should remove the items', () => {

--- a/test/commands/zpopmin.js
+++ b/test/commands/zpopmin.js
@@ -16,7 +16,9 @@ describe('zpopmin', () => {
   it('should return first item with score', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zpopmin('foo').then(res => expect(res).toEqual(['first', 1]));
+    return redis
+      .zpopmin('foo')
+      .then((res) => expect(res).toEqual(['first', 1]));
   });
 
   it('should return first N item with score if count=N', () => {
@@ -24,13 +26,15 @@ describe('zpopmin', () => {
 
     return redis
       .zpopmin('foo', 3)
-      .then(res => expect(res).toEqual(['first', 1, 'second', 2, 'third', 3]));
+      .then((res) =>
+        expect(res).toEqual(['first', 1, 'second', 2, 'third', 3])
+      );
   });
 
   it('should return empty list if no data', () => {
     const redis = new MockRedis({ data: {} });
 
-    return redis.zpopmin('foo').then(res => expect(res).toEqual([]));
+    return redis.zpopmin('foo').then((res) => expect(res).toEqual([]));
   });
 
   it('should remove the items', () => {

--- a/test/commands/zrange.js
+++ b/test/commands/zrange.js
@@ -19,7 +19,7 @@ describe('zrange', () => {
 
     return redis
       .zrange('foo', 0, 2)
-      .then(res => expect(res).toEqual(['first', 'second', 'third']));
+      .then((res) => expect(res).toEqual(['first', 'second', 'third']));
   });
 
   it('should return last 3 items', () => {
@@ -27,7 +27,7 @@ describe('zrange', () => {
 
     return redis
       .zrange('foo', -3, -1)
-      .then(res => expect(res).toEqual(['third', 'fourth', 'fifth']));
+      .then((res) => expect(res).toEqual(['third', 'fourth', 'fifth']));
   });
 
   it('should return all items on larger ranges', () => {
@@ -35,7 +35,7 @@ describe('zrange', () => {
 
     return redis
       .zrange('foo', 0, 100)
-      .then(res =>
+      .then((res) =>
         expect(res).toEqual(['first', 'second', 'third', 'fourth', 'fifth'])
       );
   });
@@ -43,7 +43,7 @@ describe('zrange', () => {
   it('should return empty array if out-of-range', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zrange('foo', 10, 100).then(res => expect(res).toEqual([]));
+    return redis.zrange('foo', 10, 100).then((res) => expect(res).toEqual([]));
   });
 
   it('should return empty array if the key contains something other than a list', () => {
@@ -53,14 +53,16 @@ describe('zrange', () => {
       },
     });
 
-    return redis.zrange('foo', 0, 2).then(res => expect(res).toEqual([]));
+    return redis.zrange('foo', 0, 2).then((res) => expect(res).toEqual([]));
   });
 
   it('should include scores if WITHSCORES is specified', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrange('foo', 0, 2, 'WITHSCORES')
-      .then(res => expect(res).toEqual(['first', 1, 'second', 2, 'third', 3]));
+      .then((res) =>
+        expect(res).toEqual(['first', 1, 'second', 2, 'third', 3])
+      );
   });
 
   it('should sort items with the same score lexicographically', () => {
@@ -77,6 +79,6 @@ describe('zrange', () => {
 
     return redis
       .zrange('foo', 0, 100)
-      .then(res => expect(res).toEqual(['bbb', 'ccc', 'ddd', 'aaa']));
+      .then((res) => expect(res).toEqual(['bbb', 'ccc', 'ddd', 'aaa']));
   });
 });

--- a/test/commands/zrangebyscore.js
+++ b/test/commands/zrangebyscore.js
@@ -18,7 +18,7 @@ describe('zrangebyscore', () => {
 
     return redis
       .zrangebyscore('foo', 1, 3)
-      .then(res => expect(res).toEqual(['first', 'second', 'third']));
+      .then((res) => expect(res).toEqual(['first', 'second', 'third']));
   });
 
   it('should return using strict compare', () => {
@@ -26,7 +26,7 @@ describe('zrangebyscore', () => {
 
     return redis
       .zrangebyscore('foo', '(3', 5)
-      .then(res => expect(res).toEqual(['fourth', 'fifth']));
+      .then((res) => expect(res).toEqual(['fourth', 'fifth']));
   });
 
   it('should accept infinity string', () => {
@@ -34,7 +34,7 @@ describe('zrangebyscore', () => {
 
     return redis
       .zrangebyscore('foo', '-inf', '+inf')
-      .then(res =>
+      .then((res) =>
         expect(res).toEqual(['first', 'second', 'third', 'fourth', 'fifth'])
       );
   });
@@ -44,7 +44,7 @@ describe('zrangebyscore', () => {
 
     return redis
       .zrangebyscore('foo', 10, 100)
-      .then(res => expect(res).toEqual([]));
+      .then((res) => expect(res).toEqual([]));
   });
 
   it('should return empty array if key not found', () => {
@@ -52,7 +52,7 @@ describe('zrangebyscore', () => {
 
     return redis
       .zrangebyscore('boo', 10, 100)
-      .then(res => expect(res).toEqual([]));
+      .then((res) => expect(res).toEqual([]));
   });
 
   it('should return empty array if the key contains something other than a list', () => {
@@ -64,14 +64,16 @@ describe('zrangebyscore', () => {
 
     return redis
       .zrangebyscore('foo', 1, 2)
-      .then(res => expect(res).toEqual([]));
+      .then((res) => expect(res).toEqual([]));
   });
 
   it('should include scores if WITHSCORES is specified', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrangebyscore('foo', 1, 3, 'WITHSCORES')
-      .then(res => expect(res).toEqual(['first', 1, 'second', 2, 'third', 3]));
+      .then((res) =>
+        expect(res).toEqual(['first', 1, 'second', 2, 'third', 3])
+      );
   });
 
   it('should sort items with the same score lexicographically', () => {
@@ -88,7 +90,7 @@ describe('zrangebyscore', () => {
 
     return redis
       .zrangebyscore('foo', '-inf', '+inf', 'WITHSCORES')
-      .then(res =>
+      .then((res) =>
         expect(res).toEqual(['bbb', 4, 'ccc', 4, 'ddd', 4, 'aaa', 5])
       );
   });
@@ -96,48 +98,50 @@ describe('zrangebyscore', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrangebyscore('foo', 1, 3, 'LIMIT', 0, 1)
-      .then(res => expect(res).toEqual(['first']));
+      .then((res) => expect(res).toEqual(['first']));
   });
   it('should handle offset and limit (1,2)', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrangebyscore('foo', 1, 3, 'LIMIT', 1, 2)
-      .then(res => expect(res).toEqual(['second', 'third']));
+      .then((res) => expect(res).toEqual(['second', 'third']));
   });
   it('should handle offset, limit, and WITHSCORES', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrangebyscore('foo', 1, 3, 'WITHSCORES', 'LIMIT', 1, 1)
-      .then(res => expect(res).toEqual(['second', 2]));
+      .then((res) => expect(res).toEqual(['second', 2]));
   });
   it('should handle LIMIT specified before WITHSCORES', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrangebyscore('foo', 1, 3, 'LIMIT', 1, 1, 'WITHSCORES')
-      .then(res => expect(res).toEqual(['second', 2]));
+      .then((res) => expect(res).toEqual(['second', 2]));
   });
   it('should handle LIMIT of -1', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrangebyscore('foo', '-inf', '+inf', 'LIMIT', 1, -1)
-      .then(res => expect(res).toEqual(['second', 'third', 'fourth']));
+      .then((res) => expect(res).toEqual(['second', 'third', 'fourth']));
   });
   it('should handle LIMIT of -1 and WITHSCORES', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrangebyscore('foo', '-inf', '+inf', 'LIMIT', 1, -1, 'WITHSCORES')
-      .then(res => expect(res).toEqual(['second', 2, 'third', 3, 'fourth', 4]));
+      .then((res) =>
+        expect(res).toEqual(['second', 2, 'third', 3, 'fourth', 4])
+      );
   });
   it('should handle LIMIT of -2', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrangebyscore('foo', '-inf', '+inf', 'LIMIT', 1, -2)
-      .then(res => expect(res).toEqual(['second', 'third']));
+      .then((res) => expect(res).toEqual(['second', 'third']));
   });
   it('should handle LIMIT of 0', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrangebyscore('foo', '-inf', '+inf', 'LIMIT', 1, 0)
-      .then(res => expect(res).toEqual([]));
+      .then((res) => expect(res).toEqual([]));
   });
 });

--- a/test/commands/zrank.js
+++ b/test/commands/zrank.js
@@ -17,7 +17,7 @@ describe('zrank', () => {
 
     return redis
       .zrank('foo', 'not-exist')
-      .then(status => expect(status).toBe(null))
+      .then((status) => expect(status).toBe(null))
       .then(() => expect(redis.data.has('foo')).toBe(false));
   });
 
@@ -26,12 +26,12 @@ describe('zrank', () => {
 
     return redis
       .zrank('foo', 'not-found')
-      .then(status => expect(status).toBe(null));
+      .then((status) => expect(status).toBe(null));
   });
 
   it('should return found index', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zrank('foo', 'third').then(status => expect(status).toBe(2));
+    return redis.zrank('foo', 'third').then((status) => expect(status).toBe(2));
   });
 });

--- a/test/commands/zrem.js
+++ b/test/commands/zrem.js
@@ -14,14 +14,14 @@ describe('zrem', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrem('foos', 'foo')
-      .then(status => expect(status).toBe(1))
+      .then((status) => expect(status).toBe(1))
       .then(() => expect(redis.data.get('foos').has('foo')).toBe(false));
   });
   it('should remove 2 items from sorted set', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrem('foos', 'foo', 'baz')
-      .then(status => expect(status).toBe(2))
+      .then((status) => expect(status).toBe(2))
       .then(() => {
         expect(redis.data.get('foos').has('foo')).toBe(false);
         expect(redis.data.get('foos').has('bar')).toBe(true);
@@ -32,14 +32,14 @@ describe('zrem', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrem('foos', 'qux')
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() => expect(redis.data.get('foos').has('qux')).toBe(false));
   });
   it('should ignore non-existent keys', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrem('bars', 'bar')
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() => expect(redis.data.get('bars')).toNotExist());
   });
 });

--- a/test/commands/zremrangebyrank.js
+++ b/test/commands/zremrangebyrank.js
@@ -19,7 +19,7 @@ describe('zremrangebyrank', () => {
 
     return redis
       .zremrangebyrank('foo', 0, 2)
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() => expect(redis.data.has('foo')).toBe(false));
   });
 
@@ -28,7 +28,7 @@ describe('zremrangebyrank', () => {
 
     return redis
       .zremrangebyrank('foo', 0, 2)
-      .then(status => expect(status).toBe(3))
+      .then((status) => expect(status).toBe(3))
       .then(() => {
         expect(redis.data.get('foo').has('first')).toBe(false);
         expect(redis.data.get('foo').has('second')).toBe(false);
@@ -43,7 +43,7 @@ describe('zremrangebyrank', () => {
 
     return redis
       .zremrangebyrank('foo', -3, -1)
-      .then(status => expect(status).toBe(3))
+      .then((status) => expect(status).toBe(3))
       .then(() => {
         expect(redis.data.get('foo').has('first')).toBe(true);
         expect(redis.data.get('foo').has('second')).toBe(true);
@@ -58,7 +58,7 @@ describe('zremrangebyrank', () => {
 
     return redis
       .zremrangebyrank('foo', 0, 100)
-      .then(status => expect(status).toBe(5))
+      .then((status) => expect(status).toBe(5))
       .then(() => {
         expect(redis.data.get('foo').has('first')).toBe(false);
         expect(redis.data.get('foo').has('second')).toBe(false);
@@ -73,7 +73,7 @@ describe('zremrangebyrank', () => {
 
     return redis
       .zremrangebyrank('foo', 10, 100)
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() => {
         expect(redis.data.get('foo').has('first')).toBe(true);
         expect(redis.data.get('foo').has('second')).toBe(true);
@@ -90,6 +90,8 @@ describe('zremrangebyrank', () => {
       },
     });
 
-    return redis.zremrangebyrank('foo', 0, 2).then(res => expect(res).toBe(0));
+    return redis
+      .zremrangebyrank('foo', 0, 2)
+      .then((res) => expect(res).toBe(0));
   });
 });

--- a/test/commands/zremrangebyscore.js
+++ b/test/commands/zremrangebyscore.js
@@ -19,7 +19,7 @@ describe('zremrangebyscore', () => {
 
     return redis
       .zremrangebyscore('foo', 0, 2)
-      .then(status => expect(status).toBe(0))
+      .then((status) => expect(status).toBe(0))
       .then(() => expect(redis.data.has('foo')).toBe(false));
   });
 
@@ -28,7 +28,7 @@ describe('zremrangebyscore', () => {
 
     return redis
       .zremrangebyscore('foo', 1, 3)
-      .then(res => expect(res).toBe(3))
+      .then((res) => expect(res).toBe(3))
       .then(() => {
         expect(redis.data.get('foo').has('first')).toBe(false);
         expect(redis.data.get('foo').has('second')).toBe(false);
@@ -43,7 +43,7 @@ describe('zremrangebyscore', () => {
 
     return redis
       .zremrangebyscore('foo', '(3', 5)
-      .then(res => expect(res).toEqual(2))
+      .then((res) => expect(res).toEqual(2))
       .then(() => {
         expect(redis.data.get('foo').has('first')).toBe(true);
         expect(redis.data.get('foo').has('second')).toBe(true);
@@ -58,7 +58,7 @@ describe('zremrangebyscore', () => {
 
     return redis
       .zremrangebyscore('foo', '-inf', '+inf')
-      .then(res => expect(res).toEqual(5))
+      .then((res) => expect(res).toEqual(5))
       .then(() => {
         expect(redis.data.get('foo').has('first')).toBe(false);
         expect(redis.data.get('foo').has('second')).toBe(false);
@@ -73,7 +73,7 @@ describe('zremrangebyscore', () => {
 
     return redis
       .zremrangebyscore('foo', 100, 10)
-      .then(res => expect(res).toEqual(0));
+      .then((res) => expect(res).toEqual(0));
   });
 
   it('should return zero if key not found', () => {
@@ -81,7 +81,7 @@ describe('zremrangebyscore', () => {
 
     return redis
       .zremrangebyscore('boo', 100, 10)
-      .then(res => expect(res).toEqual(0));
+      .then((res) => expect(res).toEqual(0));
   });
 
   it('should return zero if the key contains something other than a list', () => {
@@ -93,6 +93,6 @@ describe('zremrangebyscore', () => {
 
     return redis
       .zremrangebyscore('foo', 2, 1)
-      .then(res => expect(res).toEqual(0));
+      .then((res) => expect(res).toEqual(0));
   });
 });

--- a/test/commands/zrevrange.js
+++ b/test/commands/zrevrange.js
@@ -18,7 +18,7 @@ describe('zrevrange', () => {
 
     return redis
       .zrevrange('foo', 0, 2)
-      .then(res => expect(res).toEqual(['fifth', 'fourth', 'third']));
+      .then((res) => expect(res).toEqual(['fifth', 'fourth', 'third']));
   });
 
   it('should return last 3 items in reverse', () => {
@@ -26,7 +26,7 @@ describe('zrevrange', () => {
 
     return redis
       .zrevrange('foo', -3, -1)
-      .then(res => expect(res).toEqual(['third', 'second', 'first']));
+      .then((res) => expect(res).toEqual(['third', 'second', 'first']));
   });
 
   it('should return last all items on larger numbers in reverse', () => {
@@ -34,7 +34,7 @@ describe('zrevrange', () => {
 
     return redis
       .zrevrange('foo', 0, 100)
-      .then(res =>
+      .then((res) =>
         expect(res).toEqual(['fifth', 'fourth', 'third', 'second', 'first'])
       );
   });
@@ -42,7 +42,9 @@ describe('zrevrange', () => {
   it('should return empty array if out-of-range', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zrevrange('foo', 10, 100).then(res => expect(res).toEqual([]));
+    return redis
+      .zrevrange('foo', 10, 100)
+      .then((res) => expect(res).toEqual([]));
   });
 
   it('should return empty array if the key contains something other than a list', () => {
@@ -52,7 +54,7 @@ describe('zrevrange', () => {
       },
     });
 
-    return redis.zrevrange('foo', 0, 2).then(res => expect(res).toEqual([]));
+    return redis.zrevrange('foo', 0, 2).then((res) => expect(res).toEqual([]));
   });
 
   it('should sort items with the same score in reverse lexicographical order', () => {
@@ -69,6 +71,6 @@ describe('zrevrange', () => {
 
     return redis
       .zrevrange('foo', 0, 100)
-      .then(res => expect(res).toEqual(['aaa', 'ddd', 'ccc', 'bbb']));
+      .then((res) => expect(res).toEqual(['aaa', 'ddd', 'ccc', 'bbb']));
   });
 });

--- a/test/commands/zrevrangebyscore.js
+++ b/test/commands/zrevrangebyscore.js
@@ -18,7 +18,7 @@ describe('zrevrangebyscore', () => {
 
     return redis
       .zrevrangebyscore('foo', 3, 1)
-      .then(res => expect(res).toEqual(['third', 'second', 'first']));
+      .then((res) => expect(res).toEqual(['third', 'second', 'first']));
   });
 
   it('should return using strict compare', () => {
@@ -26,7 +26,7 @@ describe('zrevrangebyscore', () => {
 
     return redis
       .zrevrangebyscore('foo', 5, '(3')
-      .then(res => expect(res).toEqual(['fifth', 'fourth']));
+      .then((res) => expect(res).toEqual(['fifth', 'fourth']));
   });
 
   it('should accept infinity string', () => {
@@ -34,7 +34,7 @@ describe('zrevrangebyscore', () => {
 
     return redis
       .zrevrangebyscore('foo', '+inf', '-inf')
-      .then(res =>
+      .then((res) =>
         expect(res).toEqual(['fifth', 'fourth', 'third', 'second', 'first'])
       );
   });
@@ -44,7 +44,7 @@ describe('zrevrangebyscore', () => {
 
     return redis
       .zrevrangebyscore('foo', 100, 10)
-      .then(res => expect(res).toEqual([]));
+      .then((res) => expect(res).toEqual([]));
   });
 
   it('should return empty array if key not found', () => {
@@ -52,7 +52,7 @@ describe('zrevrangebyscore', () => {
 
     return redis
       .zrevrangebyscore('boo', 100, 10)
-      .then(res => expect(res).toEqual([]));
+      .then((res) => expect(res).toEqual([]));
   });
 
   it('should return empty array if the key contains something other than a list', () => {
@@ -64,14 +64,16 @@ describe('zrevrangebyscore', () => {
 
     return redis
       .zrevrangebyscore('foo', 2, 1)
-      .then(res => expect(res).toEqual([]));
+      .then((res) => expect(res).toEqual([]));
   });
 
   it('should include scores if WITHSCORES is specified', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrevrangebyscore('foo', 3, 1, 'WITHSCORES')
-      .then(res => expect(res).toEqual(['third', 3, 'second', 2, 'first', 1]));
+      .then((res) =>
+        expect(res).toEqual(['third', 3, 'second', 2, 'first', 1])
+      );
   });
 
   it('should sort items with the same score in reverse lexicographical order', () => {
@@ -88,7 +90,7 @@ describe('zrevrangebyscore', () => {
 
     return redis
       .zrevrangebyscore('foo', '+inf', '-inf', 'WITHSCORES')
-      .then(res =>
+      .then((res) =>
         expect(res).toEqual(['aaa', 5, 'ddd', 4, 'ccc', 4, 'bbb', 4])
       );
   });
@@ -97,48 +99,50 @@ describe('zrevrangebyscore', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrevrangebyscore('foo', 3, 1, 'LIMIT', 0, 1)
-      .then(res => expect(res).toEqual(['third']));
+      .then((res) => expect(res).toEqual(['third']));
   });
   it('should handle offset and limit (1,2)', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrevrangebyscore('foo', 3, 1, 'LIMIT', 1, 2)
-      .then(res => expect(res).toEqual(['second', 'first']));
+      .then((res) => expect(res).toEqual(['second', 'first']));
   });
   it('should handle offset, limit, and WITHSCORES', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrevrangebyscore('foo', 3, 1, 'WITHSCORES', 'LIMIT', 1, 1)
-      .then(res => expect(res).toEqual(['second', 2]));
+      .then((res) => expect(res).toEqual(['second', 2]));
   });
   it('should handle LIMIT specified before WITHSCORES', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrevrangebyscore('foo', 3, 1, 'LIMIT', 1, 1, 'WITHSCORES')
-      .then(res => expect(res).toEqual(['second', 2]));
+      .then((res) => expect(res).toEqual(['second', 2]));
   });
   it('should handle LIMIT of -1', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrevrangebyscore('foo', '+inf', '-inf', 'LIMIT', 1, -1)
-      .then(res => expect(res).toEqual(['fourth', 'third', 'second']));
+      .then((res) => expect(res).toEqual(['fourth', 'third', 'second']));
   });
   it('should handle LIMIT of -1 and WITHSCORES', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrevrangebyscore('foo', '+inf', '-inf', 'LIMIT', 1, -1, 'WITHSCORES')
-      .then(res => expect(res).toEqual(['fourth', 4, 'third', 3, 'second', 2]));
+      .then((res) =>
+        expect(res).toEqual(['fourth', 4, 'third', 3, 'second', 2])
+      );
   });
   it('should handle LIMIT of -2', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrevrangebyscore('foo', '+inf', '-inf', 'LIMIT', 1, -2)
-      .then(res => expect(res).toEqual(['fourth', 'third']));
+      .then((res) => expect(res).toEqual(['fourth', 'third']));
   });
   it('should handle LIMIT of 0', () => {
     const redis = new MockRedis({ data });
     return redis
       .zrevrangebyscore('foo', '+inf', '-inf', 'LIMIT', 1, 0)
-      .then(res => expect(res).toEqual([]));
+      .then((res) => expect(res).toEqual([]));
   });
 });

--- a/test/commands/zrevrank.js
+++ b/test/commands/zrevrank.js
@@ -17,7 +17,7 @@ describe('zrevrank', () => {
 
     return redis
       .zrevrank('foo', 'not-exist')
-      .then(status => expect(status).toBe(null))
+      .then((status) => expect(status).toBe(null))
       .then(() => expect(redis.data.has('foo')).toBe(false));
   });
 
@@ -26,7 +26,7 @@ describe('zrevrank', () => {
 
     return redis
       .zrevrank('foo', 'not-found')
-      .then(status => expect(status).toBe(null));
+      .then((status) => expect(status).toBe(null));
   });
 
   it('should return found index', () => {
@@ -34,6 +34,6 @@ describe('zrevrank', () => {
 
     return redis
       .zrevrank('foo', 'first')
-      .then(status => expect(status).toBe(2));
+      .then((status) => expect(status).toBe(2));
   });
 });

--- a/test/commands/zscore.js
+++ b/test/commands/zscore.js
@@ -18,24 +18,24 @@ describe('zscore', () => {
   it('should return the score of an existing member as a string', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zscore('foo', 'third').then(res => expect(res).toBe('3'));
+    return redis.zscore('foo', 'third').then((res) => expect(res).toBe('3'));
   });
 
   it('should return null when the member does not exist', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zscore('foo', 'sixth').then(res => expect(res).toNotExist());
+    return redis.zscore('foo', 'sixth').then((res) => expect(res).toNotExist());
   });
 
   it('should return null when the key is not a sorted set', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zscore('bar', 'first').then(res => expect(res).toNotExist());
+    return redis.zscore('bar', 'first').then((res) => expect(res).toNotExist());
   });
 
   it('should return null when the key does not exist', () => {
     const redis = new MockRedis({ data });
 
-    return redis.zscore('baz', 'first').then(res => expect(res).toNotExist());
+    return redis.zscore('baz', 'first').then((res) => expect(res).toNotExist());
   });
 });

--- a/test/events.js
+++ b/test/events.js
@@ -3,7 +3,7 @@ import expect, { createSpy } from 'expect';
 import MockRedis from '../src';
 
 describe('events', () => {
-  it('should trigger ready and connect events on instantiation', done => {
+  it('should trigger ready and connect events on instantiation', (done) => {
     const redis = new MockRedis({});
     const readySpy = createSpy();
     const connectSpy = createSpy();

--- a/test/exec.js
+++ b/test/exec.js
@@ -12,12 +12,20 @@ describe('exec', () => {
     });
 
     return redis
-      .multi([['incr', 'user_next'], ['incr', 'post_next']])
+      .multi([
+        ['incr', 'user_next'],
+        ['incr', 'post_next'],
+      ])
       .exec()
-      .then(results => expect(results).toEqual([[null, 2], [null, 2]]));
+      .then((results) =>
+        expect(results).toEqual([
+          [null, 2],
+          [null, 2],
+        ])
+      );
   });
 
-  it('should support a callback function', done => {
+  it('should support a callback function', (done) => {
     const redis = new MockRedis({
       data: {
         user_next: '1',
@@ -26,9 +34,15 @@ describe('exec', () => {
     });
 
     redis
-      .multi([['incr', 'user_next'], ['incr', 'post_next']])
+      .multi([
+        ['incr', 'user_next'],
+        ['incr', 'post_next'],
+      ])
       .exec((err, results) => {
-        expect(results).toEqual([[null, 2], [null, 2]]);
+        expect(results).toEqual([
+          [null, 2],
+          [null, 2],
+        ]);
         done();
       });
   });

--- a/test/keyprefix.js
+++ b/test/keyprefix.js
@@ -7,7 +7,7 @@ import MockRedis from '../src';
 
 describe('keyprefix', () => {
   let writable;
-  const flatten = wrt => _.flatten(wrt.data);
+  const flatten = (wrt) => _.flatten(wrt.data);
 
   beforeEach(() => {
     writable = new ObjectWritableMock({ objectMode: true });
@@ -16,12 +16,12 @@ describe('keyprefix', () => {
   describe('get', () => {
     it('should return null on keys that do not exist', () => {
       const redis = new MockRedis({ keyPrefix: 'test:' });
-      return redis.get('foo').then(result => expect(result).toBe(null));
+      return redis.get('foo').then((result) => expect(result).toBe(null));
     });
 
     it('should return null on keys that do not exist', () => {
       const redis = new MockRedis({ keyPrefix: 'test:' });
-      return redis.get('foo').then(result => expect(result).toBe(null));
+      return redis.get('foo').then((result) => expect(result).toBe(null));
     });
 
     it('should return value of key', () => {
@@ -32,7 +32,7 @@ describe('keyprefix', () => {
         keyPrefix: 'test:',
       });
 
-      return redis.get('foo').then(result => expect(result).toBe('bar'));
+      return redis.get('foo').then((result) => expect(result).toBe('bar'));
     });
   });
 
@@ -41,7 +41,7 @@ describe('keyprefix', () => {
       const redis = new MockRedis({ keyPrefix: 'test:' });
       return redis
         .set('foo', 'bar')
-        .then(status => expect(status).toBe('OK'))
+        .then((status) => expect(status).toBe('OK'))
         .then(() => expect(redis.data.get('foo')).toBe('bar'));
     });
 
@@ -49,7 +49,7 @@ describe('keyprefix', () => {
       const redis = new MockRedis({ keyPrefix: 'test:' });
       return redis
         .set('foo', 1.5)
-        .then(status => expect(status).toBe('OK'))
+        .then((status) => expect(status).toBe('OK'))
         .then(() => expect(redis.data.get('foo')).toBe('1.5'));
     });
   });
@@ -66,16 +66,16 @@ describe('keyprefix', () => {
     it('should delete passed in keys', () =>
       redis
         .del('deleteme', 'metoo')
-        .then(status => expect(status).toBe(2))
+        .then((status) => expect(status).toBe(2))
         .then(() => expect(redis.data.has('deleteme')).toBe(false))
         .then(() => expect(redis.data.has('metoo')).toBe(false)));
 
     it('return the number of keys removed', () =>
-      redis.del('deleteme', 'metoo').then(status => expect(status).toBe(0)));
+      redis.del('deleteme', 'metoo').then((status) => expect(status).toBe(0)));
   });
 
   describe('scanSream', () => {
-    it('should batch by count', done => {
+    it('should batch by count', (done) => {
       // Given
       const chance = new Chance();
       const keys = chance.unique(chance.word, 100);
@@ -95,7 +95,7 @@ describe('keyprefix', () => {
       });
     });
 
-    it('should return  keys', done => {
+    it('should return  keys', (done) => {
       // Given
       const redis = new MockRedis({
         data: {
@@ -115,7 +115,7 @@ describe('keyprefix', () => {
       });
     });
 
-    it('should return only mathced keys', done => {
+    it('should return only mathced keys', (done) => {
       // Given
       const redis = new MockRedis({
         data: {
@@ -151,22 +151,22 @@ describe('keyprefix', () => {
     });
 
     it('should return value of key using prefix', () =>
-      redis1.get('foo').then(result => expect(result).toEqual('bar')));
+      redis1.get('foo').then((result) => expect(result).toEqual('bar')));
 
     it('should return null on keys that do not exist for that prefix', () =>
-      redis2.get('foo').then(result => expect(result).toBe(null)));
+      redis2.get('foo').then((result) => expect(result).toBe(null)));
 
     it('setting with one prefix should not affect same key with another prefix', () =>
       redis2
         .set('hello', 'ioredis')
-        .then(status => expect(status).toBe('OK'))
+        .then((status) => expect(status).toBe('OK'))
         .then(() => redis1.get('hello'))
-        .then(result => expect(result).toBe('world')));
+        .then((result) => expect(result).toBe('world')));
 
     it('should return value of key if the prefix is the same', () =>
       redis2
         .set('hello', 'ioredis')
-        .then(status => expect(status).toBe('OK'))
+        .then((status) => expect(status).toBe('OK'))
         .then(() => expect(redis2.data.get('hello')).toBe('ioredis')));
   });
 });

--- a/test/keyspace-notifications.js
+++ b/test/keyspace-notifications.js
@@ -66,7 +66,7 @@ describe('parseKeyspaceEvents', () => {
 });
 
 describe('keyspaceNotifications', () => {
-  it('should appear when configured and the triggering event occurs', done => {
+  it('should appear when configured and the triggering event occurs', (done) => {
     const redis = new MockRedis({ notifyKeyspaceEvents: 'gK' }); // gK: generic keyspace
     const redisPubSub = redis.createConnectedClient();
     redisPubSub.on('message', (channel, message) => {
@@ -79,7 +79,7 @@ describe('keyspaceNotifications', () => {
       .then(() => redis.set('key', 'value').then(() => redis.del('key')));
   });
 
-  it('should not appear when not configured and the triggering event occurs', done => {
+  it('should not appear when not configured and the triggering event occurs', (done) => {
     const redis = new MockRedis({ notifyKeyspaceEvents: '' }); // empty string: not configured
     redis.on('message', (channel, message) => {
       throw new Error(`should not receive ${message} on ${channel}`);
@@ -89,7 +89,7 @@ describe('keyspaceNotifications', () => {
     setTimeout(() => done(), 40);
   });
 
-  it('should appear on a connected second mock instance when configured and the triggering event occurs', done => {
+  it('should appear on a connected second mock instance when configured and the triggering event occurs', (done) => {
     const redis = new MockRedis({ notifyKeyspaceEvents: 'gK' }); // gK: generic keyspace
     const redis2 = redis.createConnectedClient({ notifyKeyspaceEvents: 'gK' });
     redis2.on('message', (channel, message) => {
@@ -104,7 +104,7 @@ describe('keyspaceNotifications', () => {
 });
 
 describe('keyeventNotifications', () => {
-  it('should appear when configured and the triggering event occurs', done => {
+  it('should appear when configured and the triggering event occurs', (done) => {
     const redis = new MockRedis({ notifyKeyspaceEvents: 'gE' }); // gK: generic keyevent
     const redisPubSub = redis.createConnectedClient();
     redisPubSub.on('message', (channel, message) => {

--- a/test/lua.js
+++ b/test/lua.js
@@ -78,7 +78,7 @@ describe('lua', () => {
             args.push(a);
             a += 1;
           }
-          const argu = args.map(i => interop.tojs(vm.L, i));
+          const argu = args.map((i) => interop.tojs(vm.L, i));
 
           wasCalledWith = argu;
 

--- a/test/multi.js
+++ b/test/multi.js
@@ -6,7 +6,10 @@ describe('multi', () => {
   it('should setup a batch queue that can be passed to exec', () => {
     const redis = new MockRedis();
 
-    redis.multi([['incr', 'user_next'], ['incr', 'post_next']]);
+    redis.multi([
+      ['incr', 'user_next'],
+      ['incr', 'post_next'],
+    ]);
     expect(redis.batch).toBeA('object');
     expect(redis.batch.batch).toBeA('array');
     expect(redis.batch.batch.length).toBe(2);
@@ -22,7 +25,7 @@ describe('multi', () => {
       .incr('user_next')
       .incr('post_next')
       .exec()
-      .then(results => {
+      .then((results) => {
         expect(results).toBeA('array');
         expect(results.length).toBe(2);
         expect(results[0]).toEqual([null, 1]);
@@ -49,7 +52,7 @@ describe('multi', () => {
       })
       .incr('foo_next')
       .exec()
-      .then(results => {
+      .then((results) => {
         expect(results).toBeA('array');
         expect(results.length).toBe(4);
         expect(internalCallsCounter).toEqual(2);
@@ -66,7 +69,7 @@ describe('multi', () => {
     return redis
       .pipeline(commands)
       .exec()
-      .then(results => {
+      .then((results) => {
         expect(results).toBeA('array');
         expect(results.length).toBe(2);
         expect(results[0]).toEqual([null, 'OK']);
@@ -79,7 +82,10 @@ describe('multi', () => {
 
   it('should increment _transactions', () => {
     const redis = new MockRedis();
-    const commands = [['incr', 'user_next'], ['incr', 'post_next']];
+    const commands = [
+      ['incr', 'user_next'],
+      ['incr', 'post_next'],
+    ];
     redis.multi(commands);
     // eslint-disable-next-line no-underscore-dangle
     expect(redis.batch._transactions).toEqual(commands.length + 1);
@@ -88,7 +94,7 @@ describe('multi', () => {
   it('errors if you exec without starting a pipeline', () => {
     const redis = new MockRedis();
 
-    return redis.exec().catch(err => {
+    return redis.exec().catch((err) => {
       expect(err).toBeA(Error);
     });
   });

--- a/test/multiple-mocks.js
+++ b/test/multiple-mocks.js
@@ -7,11 +7,11 @@ describe('multipleMocks', () => {
     const client1 = new MockRedis();
     const client2 = client1.createConnectedClient();
     client1.hset('testing', 'test', '2').then(() => {
-      client2.hget('testing', 'test').then(val => expect(val).toBe('2'));
+      client2.hget('testing', 'test').then((val) => expect(val).toBe('2'));
     });
   });
 
-  it('should be possible to create a second IORedis client, which is working on shared channels with the first client', done => {
+  it('should be possible to create a second IORedis client, which is working on shared channels with the first client', (done) => {
     const client1 = new MockRedis();
     const client2 = client1.createConnectedClient();
     client1.on('message', (channel, message) => {


### PR DESCRIPTION
We've transpiled for node `v0.10.16` for quite some time. We started off by supporting the same versions of node as `ioredis` itself, even though it's caused some disadvantages. Like locking us to mocha, as jest and other test frameworks don't work on old versions that lost support long ago.

This PR will bump our transpilation to require node v10 and later, as it's the oldest version still receiving security patches and it'll allow us to use different testing frameworks and make wide codebase refactors much much easier to do.