### PR TITLE
feat: HSET: add support for multiple fields

### DIFF
--- a/src/commands/hset.js
+++ b/src/commands/hset.js
@@ -1,16 +1,21 @@
-export function hset(key, hashKey, hashVal) {
+export function hset(key, ...keyValuePairs) {
   if (!this.data.has(key)) {
     this.data.set(key, {});
   }
 
-  let reply = 1;
   const hash = this.data.get(key);
+  let reply = 0;
 
-  if ({}.hasOwnProperty.call(hash, hashKey)) {
-    reply = 0;
+  for (let i = 0; i < keyValuePairs.length; i += 2) {
+    const field = keyValuePairs[i]
+    const value = keyValuePairs[i + 1]
+
+    if (!{}.hasOwnProperty.call(hash, field)) {
+      reply++;
+    }
+
+    hash[field] = value;
   }
-
-  hash[hashKey] = hashVal;
 
   this.data.set(key, hash);
 

--- a/test/commands/hset.js
+++ b/test/commands/hset.js
@@ -22,4 +22,15 @@ describe('hset', () => {
           email: 'bruce@wayne.enterprises',
         })
       ));
+
+  it('should allo setting multiple fields', () =>
+    redis
+      .hset('user:1', 'email', 'bruce@wayne.enterprises', 'age', '24')
+      .then((status) => expect(status).toBe(1))
+      .then(() =>
+        expect(redis.data.get('user:1')).toEqual({
+          email: 'bruce@wayne.enterprises',
+          age: '24',
+        })
+      ));
 });


### PR DESCRIPTION
As of Redis 4.0.0, HSET is variadic and allows for multiple field/value pairs.

This PR catches up with that.