### PR TITLE
feat: add buffer support to append command

### DIFF
--- a/src/commands/append.js
+++ b/src/commands/append.js
@@ -1,7 +1,16 @@
+import createBuffer from '../buffer';
+
 export function append(key, value) {
   if (!this.data.has(key)) {
     this.data.set(key, '');
   }
-  this.data.set(key, this.data.get(key) + value);
+  if (value instanceof Buffer) {
+    this.data.set(
+      key,
+      Buffer.concat([createBuffer(this.data.get(key)), value])
+    );
+  } else {
+    this.data.set(key, this.data.get(key) + value);
+  }
   return this.data.get(key).length;
 }

--- a/test/commands/append.js
+++ b/test/commands/append.js
@@ -21,4 +21,27 @@ describe('append', () => {
       .then((newLength) => expect(newLength).toBe(6))
       .then(() => expect(redis.data.get('mykey')).toBe(' World'));
   });
+  it('should append to exiting buffer and return new length', () => {
+    const redis = new MockRedis({
+      data: {
+        mykey: Buffer.from('Hello'),
+      },
+    });
+
+    return redis
+      .append('mykey', Buffer.from(' World'))
+      .then((newLength) => expect(newLength).toBe(11))
+      .then(() =>
+        expect(redis.data.get('mykey')).toEqual(Buffer.from('Hello World'))
+      );
+  });
+  it('should set empty buffer if key does not exist', () => {
+    const redis = new MockRedis();
+    const buffer = Buffer.from('Hello World');
+
+    return redis
+      .append('mykey', buffer)
+      .then((newLength) => expect(newLength).toBe(buffer.length))
+      .then(() => expect(redis.data.get('mykey')).toEqual(buffer));
+  });
 });


### PR DESCRIPTION
Added Buffer support to the append command.

It uses Buffer.concat which was added in node v0.7.11