### PR TITLE
fix: negative stop offset larger than set size in zrange

### DIFF
--- a/src/commands/zrange-command.common.js
+++ b/src/commands/zrange-command.common.js
@@ -1,22 +1,5 @@
-function normalizeIndex(index, array) {
-  if (index < 0) {
-    return -index > array.length ? 0 : array.length + index;
-  }
-  return index;
-}
-
-export function slice(arr, s, e) {
-  const start = normalizeIndex(s, arr);
-  const end = normalizeIndex(e, arr);
-  if (end === -1) {
-    return [];
-  }
-  if (end - start < 0) {
-    return Array.from(arr)
-      .reverse()
-      .slice(start, end + 1);
-  }
-  return arr.slice(start, end + 1);
+export function slice(arr, start, end) {
+  return arr.slice(start, end === -1 ? undefined : end + 1);
 }
 
 function normalizeCountToIndex(offset, count, array) {

--- a/test/commands/zrange.js
+++ b/test/commands/zrange.js
@@ -21,6 +21,18 @@ describe('zrange', () => {
       .then((res) => expect(res).toEqual(['first', 'second', 'third']));
   });
 
+  it('should return nothing when min > max', () => {
+    const redis = new MockRedis({ data });
+
+    return redis.zrange('foo', 2, 0).then((res) => expect(res).toEqual([]));
+  });
+
+  it('should return nothing if the min is greater than the max, and max is negative', () => {
+    const redis = new MockRedis({ data });
+
+    return redis.zrange('foo', 0, -8).then((res) => expect(res).toEqual([]));
+  });
+
   it('should return last 3 items', () => {
     const redis = new MockRedis({ data });
 
@@ -37,6 +49,14 @@ describe('zrange', () => {
       .then((res) =>
         expect(res).toEqual(['first', 'second', 'third', 'fourth', 'fifth'])
       );
+  });
+
+  it('should work even if the min is negative and larger than set size', () => {
+    const redis = new MockRedis({ data });
+
+    return redis
+      .zrange('foo', -200, -3)
+      .then((res) => expect(res).toEqual(['first', 'second', 'third']));
   });
 
   it('should return empty array if out-of-range', () => {

--- a/test/commands/zremrangebyrank.js
+++ b/test/commands/zremrangebyrank.js
@@ -82,6 +82,21 @@ describe('zremrangebyrank', () => {
       });
   });
 
+  it('should remove nothing if max is before min', () => {
+    const redis = new MockRedis({ data });
+
+    return redis
+      .zremrangebyrank('foo', 0, -6)
+      .then((status) => expect(status).toBe(0))
+      .then(() => {
+        expect(redis.data.get('foo').has('first')).toBe(true);
+        expect(redis.data.get('foo').has('second')).toBe(true);
+        expect(redis.data.get('foo').has('third')).toBe(true);
+        expect(redis.data.get('foo').has('fourth')).toBe(true);
+        expect(redis.data.get('foo').has('fifth')).toBe(true);
+      });
+  });
+
   it('should return 0 the key contains something other than a list', () => {
     const redis = new MockRedis({
       data: {


### PR DESCRIPTION
This is a fix for this issue: https://github.com/stipsan/ioredis-mock/issues/992

