### PR TITLE
fix(Memory Leak): .quit() should remove subscriptions

### DIFF
--- a/src/commands/quit.js
+++ b/src/commands/quit.js
@@ -1,3 +1,4 @@
 export function quit() {
+  this.disconnect();
   return 'OK';
 }

--- a/src/index.js
+++ b/src/index.js
@@ -104,6 +104,22 @@ class RedisMock extends EventEmitter {
 
   // eslint-disable-next-line class-methods-use-this
   disconnect() {
+    const removeFrom = ({ instanceListeners }) => {
+      if (!instanceListeners) {
+        return;
+      }
+
+      instanceListeners.forEach((mapOfInstanceToListener) => {
+        mapOfInstanceToListener.forEach((listener, instance) => {
+          if (instance === this) {
+            mapOfInstanceToListener.delete(instance);
+          }
+        });
+      });
+    };
+
+    removeFrom(this.channels);
+    removeFrom(this.patternChannels);
     // no-op
   }
 

--- a/test/multiple-mocks.js
+++ b/test/multiple-mocks.js
@@ -22,7 +22,7 @@ describe('multipleMocks', () => {
   });
 
   describe('when closing a second, shared IORedis client', () => {
-    it('should clean up opened subscriptions', async () => {
+    it('should clean up opened subscriptions', () => {
       const client = new MockRedis();
 
       const testChannel = 'hello';
@@ -38,9 +38,11 @@ describe('multipleMocks', () => {
 
       expect(numberOfListeners()).toBe(12);
 
-      await Promise.all(connectedClients.map((c) => c.quit()));
+      for (let i = 0; i < 6; i++) {
+        connectedClients[i].quit();
+      }
 
-      expect(numberOfListeners()).toBe(0);
+      expect(numberOfListeners()).toBe(6);
     });
   });
 });

--- a/test/multiple-mocks.js
+++ b/test/multiple-mocks.js
@@ -20,4 +20,27 @@ describe('multipleMocks', () => {
     client1.subscribe('channel');
     client2.publish('channel', 'hello');
   });
+
+  describe('when closing a second, shared IORedis client', () => {
+    it('should clean up opened subscriptions', async () => {
+      const client = new MockRedis();
+
+      const testChannel = 'hello';
+      const numberOfListeners = () =>
+        client.channels.instanceListeners.get(testChannel).size;
+
+      const connectedClients = [];
+      for (let i = 0; i < 12; i++) {
+        const connectedClient = client.createConnectedClient();
+        connectedClients.push(connectedClient);
+        connectedClient.subscribe(testChannel);
+      }
+
+      expect(numberOfListeners()).toBe(12);
+
+      await Promise.all(connectedClients.map((c) => c.quit()));
+
+      expect(numberOfListeners()).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
Repeatedly calling creating connected instances, subscribing to topics and then `.quit()`-ing leads to a memory leak, since listeners are never removed.
This PR fixes that.