### PR TITLE
feat: `Redis.Cluster` constructor support

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ As a difference from ioredis we currently don't support:
 
 ### Cluster(Experimental)
 
+Work on Cluster support has started, the current implementation is minimal and PRs welcome #359
+
 ```js
 var Redis = require(`ioredis-mock`)
 

--- a/README.md
+++ b/README.md
@@ -127,11 +127,11 @@ As a difference from ioredis we currently don't support:
 Work on Cluster support has started, the current implementation is minimal and PRs welcome #359
 
 ```js
-var Redis = require(`ioredis-mock`)
+var Redis = require('ioredis-mock');
 
-const cluster=new Redis.Cluster([`redis://localhost:7001`])
-const nodes=cluster.nodes
-expect(nodes.length).toEqual(1)
+const cluster = new Redis.Cluster(['redis://localhost:7001']);
+const nodes = cluster.nodes;
+expect(nodes.length).toEqual(1);
 ```
 
 ## Roadmap

--- a/README.md
+++ b/README.md
@@ -122,6 +122,16 @@ As a difference from ioredis we currently don't support:
 - the `evalsha` command
 - the `script` command
 
+### Cluster(Experimental)
+
+```js
+var Redis = require(`ioredis-mock`)
+
+const cluster=new Redis.Cluster([`redis://localhost:7001`])
+const nodes=cluster.nodes
+expect(nodes.length).toEqual(1)
+```
+
 ## Roadmap
 
 This project started off as just an utility in

--- a/src/index.js
+++ b/src/index.js
@@ -150,4 +150,13 @@ RedisMock.prototype.Command = {
   },
 };
 
+class RedisClusterMock extends RedisMock {
+  constructor(nodesOptions) {
+    super();
+    this.nodes = [];
+    nodesOptions.forEach((options) => this.nodes.push(new RedisMock(options)));
+  }
+}
+
 module.exports = RedisMock;
+module.exports.Cluster = RedisClusterMock;

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+/* eslint-disable max-classes-per-file */
 import { EventEmitter } from 'events';
 import { Command } from 'ioredis';
 import * as commands from './commands';

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -1,0 +1,25 @@
+import RedisMock from '../src';
+
+describe(`cluster`, () => {
+  it(`can create instance`, () => {
+    const cluster = new RedisMock.Cluster([`redis://localhost:6379`]);
+    return expect(cluster instanceof RedisMock.Cluster).toBeTruthy();
+  });
+
+  it(`can return correct number of nodes`, () => {
+    const nodes = [`redis://localhost:7001`, `redis://localhost:7002`];
+    const cluster = new RedisMock.Cluster(nodes);
+    expect(cluster.nodes.length).toEqual(nodes.length);
+    expect(
+      cluster.nodes.every((node) => node instanceof RedisMock)
+    ).toBeTruthy();
+  });
+
+  it(`can set and get`, () => {
+    const cluster = new RedisMock.Cluster([``]);
+    return cluster
+      .set(`k`, `v`)
+      .then(() => cluster.get(`k`))
+      .then((v) => expect(v).toEqual(`v`));
+  });
+});

--- a/test/cluster.js
+++ b/test/cluster.js
@@ -1,13 +1,13 @@
 import RedisMock from '../src';
 
-describe(`cluster`, () => {
-  it(`can create instance`, () => {
-    const cluster = new RedisMock.Cluster([`redis://localhost:6379`]);
+describe('cluster', () => {
+  it('can create instance', () => {
+    const cluster = new RedisMock.Cluster(['redis://localhost:6379']);
     return expect(cluster instanceof RedisMock.Cluster).toBeTruthy();
   });
 
-  it(`can return correct number of nodes`, () => {
-    const nodes = [`redis://localhost:7001`, `redis://localhost:7002`];
+  it('can return correct number of nodes', () => {
+    const nodes = ['redis://localhost:7001', 'redis://localhost:7002'];
     const cluster = new RedisMock.Cluster(nodes);
     expect(cluster.nodes.length).toEqual(nodes.length);
     expect(
@@ -15,11 +15,11 @@ describe(`cluster`, () => {
     ).toBeTruthy();
   });
 
-  it(`can set and get`, () => {
-    const cluster = new RedisMock.Cluster([``]);
+  it('can set and get', () => {
+    const cluster = new RedisMock.Cluster(['']);
     return cluster
-      .set(`k`, `v`)
-      .then(() => cluster.get(`k`))
-      .then((v) => expect(v).toEqual(`v`));
+      .set('k', 'v')
+      .then(() => cluster.get('k'))
+      .then((v) => expect(v).toEqual('v'));
   });
 });


### PR DESCRIPTION
### Problem

I'm using the following practice:

```js
const isUnittest = process.env.NODE_ENV === `unittest`
const Redis = require(isUnittest ? `ioredis-mock` : `ioredis`)

const cluster = new Redis.Cluster([`redis://xxxxx:6379`])
 // more code here
```

But this lib does not seem to support cluster creation yet.

### Solution

The `Redis.Cluster` constructor is all I need, hence I didn't dig deeply into the internal mechanisms of the redis cluster. I know this is far from complete, so feel free to give advice or simply reject for good :D

Related to #359