### PR TITLE
fix: Lua redis.call lists returning null

### DIFF
--- a/src/commands/defineCommand.js
+++ b/src/commands/defineCommand.js
@@ -58,9 +58,6 @@ const callToRedisCommand = (vm) =>
       return 1;
     }
     if (!!result || result === 0) {
-      if (Array.isArray(result)) {
-        result.unshift(null);
-      }
       interop.push(vm.L, result);
       return 1;
     }

--- a/src/commands/defineCommand.js
+++ b/src/commands/defineCommand.js
@@ -58,6 +58,10 @@ const callToRedisCommand = (vm) =>
       return 1;
     }
     if (!!result || result === 0) {
+      if (Array.isArray(result)) {
+        // fix for one-based indices
+        result.unshift(null);
+      }
       interop.push(vm.L, result);
       return 1;
     }

--- a/src/lua.js
+++ b/src/lua.js
@@ -72,8 +72,16 @@ const isTopArray = (L) => () => {
 
 const makeReturnValue = (L) => {
   const isArray = isTopArray(L)();
+
   if (!isArray) {
-    return interop.tojs(L, -1);
+    const retVal = interop.tojs(L, -1);
+    if (Array.isArray(retVal)) {
+      // we push 'null' into position 0 in Arrays because in lua Arrays are one-based
+      // see src/commands/defineCommand:callToRedisCommand
+      // this removes the null element before returning
+      return retVal.slice(1);
+    }
+    return retVal;
   }
 
   const arrayLength = getTopLength(L);

--- a/test/commands/defineCommand.js
+++ b/test/commands/defineCommand.js
@@ -101,7 +101,7 @@ describe('defineCommand', () => {
       .then((val) => expect(val).toEqual(['value1', 'value2']));
   });
 
-  it('should maintain one-based indexes in redis.call(zrange)', () => {
+  it('should maintain one-based indexes in lua', () => {
     const luaCode = `
       local contents = redis.call('zrange', 'set', 0, -1);
       return contents[1];

--- a/test/commands/defineCommand.js
+++ b/test/commands/defineCommand.js
@@ -101,7 +101,7 @@ describe('defineCommand', () => {
       .then((val) => expect(val).toEqual(['value1', 'value2']));
   });
 
-  it('should maintain one-based indexes in lua', () => {
+  it('should maintain one-based indices in lua', () => {
     const luaCode = `
       local contents = redis.call('zrange', 'set', 0, -1);
       return contents[1];


### PR DESCRIPTION
Fix for issue #1042

Custom commands returning lists would unexpectedly return an extra `null` value at the beginning of the array. 

My initial fix broke a previous fix for one-based indices in lua so I rewrote it and added a test for that case as well.