### PR TITLE
test(lua): #arr is off-by-one because arrays are 1-based

### DIFF
--- a/src/commands/defineCommand.js
+++ b/src/commands/defineCommand.js
@@ -62,10 +62,10 @@ const callToRedisCommand = (vm) =>
         // fix for one-based indices
         result.unshift(null);
         // https://github.com/fengari-lua/fengari-interop/blob/1626687fb15452cdd82ee522955dd1f144ea7a68/src/js.js#L845
-        result[Symbol.for("__len")] = function() {
-          const arr = this
-          return arr.length - 1
-        }
+        result[Symbol.for('__len')] = function () {
+          const arr = this;
+          return arr.length - 1;
+        };
       }
       interop.push(vm.L, result);
       return 1;

--- a/src/commands/defineCommand.js
+++ b/src/commands/defineCommand.js
@@ -61,6 +61,11 @@ const callToRedisCommand = (vm) =>
       if (Array.isArray(result)) {
         // fix for one-based indices
         result.unshift(null);
+        // https://github.com/fengari-lua/fengari-interop/blob/1626687fb15452cdd82ee522955dd1f144ea7a68/src/js.js#L845
+        result[Symbol.for("__len")] = function() {
+          const arr = this
+          return arr.length - 1
+        }
       }
       interop.push(vm.L, result);
       return 1;

--- a/test/commands/eval.js
+++ b/test/commands/eval.js
@@ -42,4 +42,13 @@ describe('eval', () => {
         .then((result) => expect(result).toEqual('10'));
     });
   });
+
+  it("repro: # is off-by-one because arrays are 1-based", async () => {
+    const redis = new Redis();
+    const retVal = await redis.eval(`
+      local members = redis.call("SMEMBERS", "nonexistant")
+      return #members
+    `);
+    expect(retVal).toEqual(0)
+  })
 });

--- a/test/commands/eval.js
+++ b/test/commands/eval.js
@@ -43,12 +43,12 @@ describe('eval', () => {
     });
   });
 
-  it("repro: # is off-by-one because arrays are 1-based", async () => {
+  it('repro: # is off-by-one because arrays are 1-based', async () => {
     const redis = new Redis();
     const retVal = await redis.eval(`
-      local members = redis.call("SMEMBERS", "nonexistant")
+      local members = redis.call('SMEMBERS', 'nonexistant')
       return #members
     `);
-    expect(retVal).toEqual(0)
-  })
+    expect(retVal).toEqual(0);
+  });
 });


### PR DESCRIPTION
Hi there! I observed a bug where `#arr` returns the wrong array length. This PR contains a reproduction test.
I haven't yet found a way to fix this easily - any ideas from the maintainers?

cc https://github.com/quirrel-dev/quirrel/issues/452