### PR TITLE
fix(xrange): handle full ids

### DIFF
--- a/src/commands/xrange.js
+++ b/src/commands/xrange.js
@@ -15,8 +15,8 @@ export function xrange(stream, start, end, ...args) {
 
   const list = this.data.get(stream);
 
-  const min = start === '-' ? -Infinity : start;
-  const max = end === '+' ? Infinity : end;
+  const min = start === '-' ? -Infinity : parseInt(start.split('-')[0], 10);
+  const max = end === '+' ? Infinity : parseInt(end.split('-')[0], 10);
 
   const result = list.filter(
     ([eventId]) => min <= parseInt(eventId, 10) && max >= parseInt(eventId, 10)

--- a/test/commands/xrange.js
+++ b/test/commands/xrange.js
@@ -74,6 +74,27 @@ describe('xrange', () => {
     });
   });
 
+  it('should handle full id', () => {
+    const redis = new Redis({
+      data: {
+        stream: [
+          ['1-0', ['key', 'val']],
+          ['2-0', ['key', 'val']],
+          ['3-0', ['key', 'val']],
+        ],
+        'stream:stream:1-0': { polled: false },
+        'stream:stream:2-0': { polled: false },
+        'stream:stream:3-0': { polled: false },
+      },
+    });
+    return redis.xrange('stream', '2-0', '+').then((events) => {
+      expect(events).toEqual([
+        ['2-0', ['key', 'val']],
+        ['3-0', ['key', 'val']],
+      ]);
+    });
+  });
+
   it('should throw with a wrong number of arguments', () => {
     const redis = new Redis();
     Promise.all([


### PR DESCRIPTION
Allow `xrange` to handle full ids returned from `xadd` (for example, `100-0`) as well as timestamp-only ids (for example, `100`).