### PR TITLE
feat: Redis.SMISMEMBER support

### DIFF
--- a/compat.md
+++ b/compat.md
@@ -158,7 +158,7 @@
 | [slaveof]              | :white_check_mark: |        :x:         | [slaveofBuffer][1]              | :white_check_mark: |        :x:         |
 | [slowlog]              | :white_check_mark: |        :x:         | [slowlogBuffer][1]              | :white_check_mark: |        :x:         |
 | [smembers]             | :white_check_mark: | :white_check_mark: | [smembersBuffer][1]             | :white_check_mark: |        :x:         |
-| [smismember]           | :white_check_mark: |        :x:         | [smismemberBuffer][1]           | :white_check_mark: |        :x:         |
+| [smismember]           | :white_check_mark: | :white_check_mark: | [smismemberBuffer][1]           | :white_check_mark: |        :x:         |
 | [smove]                | :white_check_mark: | :white_check_mark: | [smoveBuffer][1]                | :white_check_mark: |        :x:         |
 | [sort]                 | :white_check_mark: |        :x:         | [sortBuffer][1]                 | :white_check_mark: |        :x:         |
 | [spop]                 | :white_check_mark: | :white_check_mark: | [spopBuffer][1]                 | :white_check_mark: |        :x:         |

--- a/src/commands/index.js
+++ b/src/commands/index.js
@@ -94,6 +94,7 @@ export * from './setnx';
 export * from './sinter';
 export * from './sinterstore';
 export * from './sismember';
+export * from './smismember';
 export * from './smembers';
 export * from './smove';
 export * from './spop';

--- a/src/commands/smismember.js
+++ b/src/commands/smismember.js
@@ -1,0 +1,10 @@
+export function smismember(key, ...valArray) {
+  const data = this.data.get(key);
+
+  if (data) {
+    return valArray.map((val) => {
+      return data.has(val) ? 1 : 0;
+    })
+  }
+  return valArray.map((val) => 0);
+}

--- a/src/commands/smismember.js
+++ b/src/commands/smismember.js
@@ -2,9 +2,7 @@ export function smismember(key, ...valArray) {
   const data = this.data.get(key);
 
   if (data) {
-    return valArray.map((val) => {
-      return data.has(val) ? 1 : 0;
-    })
+    return valArray.map((val) => data.has(val) ? 1 : 0);
   }
-  return valArray.map((val) => 0);
+  return valArray.map(() => 0);
 }

--- a/test/commands/smismember.js
+++ b/test/commands/smismember.js
@@ -1,0 +1,24 @@
+import Redis from 'ioredis';
+
+describe('smismember', () => {
+  it('should check if each item exists in set', async () => {
+    const valuesInTheSet = ['foo', 'bar'];
+    const redis = new Redis({
+      data: {
+        setKey: new Set(valuesInTheSet),
+      },
+    });
+
+    // should take n number of values after the key
+    const result = await redis.smismember('setKey', ...valuesInTheSet);
+    expect(result).toEqual(expect.arrayContaining([1, 1]));
+
+    // should take a single value as well but return an array
+    const result2 = await redis.smismember('foos', 'foobar');
+    expect(result2).toEqual(expect.arrayContaining([0]));
+
+    // should return 0 if a value is not included in the set
+    const result3 = await redis.smismember('setKey', ...['foobar', ...valuesInTheSet]);
+    expect(result3).toEqual(expect.arrayContaining([0, 1, 1]));
+  });
+});


### PR DESCRIPTION
This PR adds a mock implementation of `MISMEMBER`

[This Redis command was added in v6.2.0](https://redis.io/commands/smismember)
[And added to ioredis in v4.21.0](https://github.com/luin/ioredis/issues/1281)
[And I updated the typescript definitions here](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56945)