### PR TITLE
fix: Fix transformers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,10 +1,9 @@
 /* eslint-disable max-classes-per-file */
 import { EventEmitter } from 'events';
-import { Command } from 'ioredis';
 import redisCommands from 'redis-commands';
 import * as commands from './commands';
 import * as commandsStream from './commands-stream';
-import createCommand from './command';
+import createCommand, { Command } from './command';
 import createData from './data';
 import createExpires from './expires';
 import emitConnectEvent from './commands-utils/emitConnectEvent';
@@ -167,17 +166,8 @@ class RedisMock extends EventEmitter {
     });
   }
 }
-RedisMock.prototype.Command = {
-  // eslint-disable-next-line no-underscore-dangle
-  transformers: Command._transformer,
-  setArgumentTransformer: (name, func) => {
-    RedisMock.prototype.Command.transformers.argument[name] = func;
-  },
 
-  setReplyTransformer: (name, func) => {
-    RedisMock.prototype.Command.transformers.reply[name] = func;
-  },
-};
+RedisMock.Command = Command;
 
 RedisMock.Cluster = class RedisClusterMock extends RedisMock {
   constructor(nodesOptions) {

--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -36,7 +36,7 @@ class Pipeline {
         args.length = lastArgIndex;
       }
       const commandEmulator = command.bind(this.redis);
-      const commandArgs = processArguments(args, commandName, this.redis);
+      const commandArgs = processArguments(args, commandName);
 
       this._addTransaction(commandEmulator, commandName, commandArgs, callback);
       return this;

--- a/test/command.js
+++ b/test/command.js
@@ -2,6 +2,18 @@ import _ from 'lodash';
 import Redis from 'ioredis';
 import command from '../src/command';
 
+// Ensure that we're getting the correct instance of Command when running in test:jest.js, as jest.js isn't designed to test code directly imported private functions like src/command
+jest.mock('ioredis', () => {
+  const { Command } = jest.requireActual('ioredis');
+  const RedisMock = jest.requireActual('../src/index');
+
+  return {
+    __esModule: true,
+    Command,
+    default: RedisMock,
+  };
+});
+
 describe('basic command', () => {
   const stub = command((...args) => args, 'testCommandName', {
     Command: { transformers: { argument: {}, reply: {} } },

--- a/test/command.js
+++ b/test/command.js
@@ -1,3 +1,5 @@
+import _ from 'lodash';
+import Redis from 'ioredis';
 import command from '../src/command';
 
 describe('basic command', () => {
@@ -29,4 +31,46 @@ describe('basic command', () => {
   it.todo(
     'should reject the promise if the first argument is bool false to allow simulating failures'
   );
+});
+
+describe('transformers', () => {
+  it('should support setReplyTransformer', async () => {
+    const redis = new Redis();
+
+    Redis.Command.setReplyTransformer('hgetall', result => {
+      expect(Array.isArray(result)).toBeTruthy();
+      expect(result.length).toEqual(4);
+
+      const arr = [];
+      for (let i = 0; i < result.length; i += 2) {
+        arr.push([String(result[i]), String(result[i + 1])]);
+      }
+      return arr;
+    });
+
+    await redis.hset('replytest', 'bar', 'baz');
+    await redis.hset('replytest', 'baz', 'quz');
+    expect(await redis.hgetall('replytest')).toEqual([['bar', 'baz'], ['baz', 'quz']]);
+    delete Redis.Command.transformers.reply.hgetall;
+  });
+
+  it('should support setArgumentTransformer', async () => {
+    const redis = new Redis();
+
+    Redis.Command.setArgumentTransformer('hmset', args => {
+      if (args.length === 2) {
+        if (typeof Map !== 'undefined' && args[1] instanceof Map) {
+          return [args[0]].concat(_.flatten(Object.entries(args[1])));
+        }
+        if (typeof args[1] === 'object' && args[1] !== null) {
+          return [args[0]].concat(_.flatten(Object.entries(args[1])));
+        }
+      }
+      return args;
+    })
+
+    await redis.hmset('argtest', { k1: 'v1', k2: 'v2' });
+    expect(await redis.hgetall('argtest')).toEqual({ k1: 'v1', k2: 'v2' });
+    delete Redis.Command.transformers.argument.hmset;
+  })
 });


### PR DESCRIPTION
The transformers implementation was never compatible with ioredis, this fixes it by defining the transformer on the main export instead of the prototype and also adds much-needed tests.

Fixes: https://github.com/stipsan/ioredis-mock/issues/1051