### PR TITLE
fix: add missing zset support for "type" command

### DIFF
--- a/src/commands/type.js
+++ b/src/commands/type.js
@@ -12,6 +12,10 @@ export function type(key) {
     return 'set';
   }
 
+  if (val instanceof Map) {
+    return 'zset';
+  }
+
   if (isArray(val)) {
     return 'list';
   }


### PR DESCRIPTION
current implementation of the type command misses the sorted set (zset) type while lots of other commands around sorted sets are implemented. This PR adds the missing code
