### PR TITLE
fix: Add duplicate function to support instance duplication for TypeScript mocks

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -106,6 +106,10 @@ class RedisMock extends EventEmitter {
     return mock;
   }
 
+  duplicate() {
+    return this.createConnectedClient()
+  }
+
   // eslint-disable-next-line class-methods-use-this
   disconnect() {
     const removeFrom = ({ instanceListeners }) => {


### PR DESCRIPTION
The io-redis types package supports the duplicate function, which is similar to what createConnectedClient does. I added the implementation of duplicate, which internally calls createConnectedClient.