### PR TITLE
fix(xadd): Accept odd number of parameters

### DIFF
--- a/src/commands/xadd.js
+++ b/src/commands/xadd.js
@@ -1,5 +1,10 @@
 export function xadd(stream, id, ...args) {
-  if (!stream || !id || args.length === 0 || args.length % 2 !== 0) {
+  if (
+    !stream ||
+    !id ||
+    args.length === 0 ||
+    (args.includes('~') ? args.length < 4 : args.length % 2 !== 0)
+  ) {
     throw new Error("ERR wrong number of arguments for 'xadd' command");
   }
   if (!this.data.has(stream)) {

--- a/test/commands/xadd.js
+++ b/test/commands/xadd.js
@@ -22,6 +22,28 @@ describe('xadd', () => {
         expect(redis.data.get(`stream:stream:${id}`)).toEqual({
           polled: false,
         });
+      })
+      .then(() =>
+        redis.xadd(
+          'stream',
+          'MAXLEN',
+          '~',
+          '50',
+          '*',
+          'reading',
+          '{"key": "value"}'
+        )
+      )
+      .then((id) => {
+        expect(id).toBe('MAXLEN-0');
+        expect(redis.data.get('stream')).toEqual([
+          ['1-0', ['key', 'val']],
+          ['2-0', ['key', 'val']],
+          ['MAXLEN-0', ['~', '50', '*', 'reading', '{"key": "value"}']],
+        ]);
+        expect(redis.data.get(`stream:stream:${id}`)).toEqual({
+          polled: false,
+        });
       });
   });
 


### PR DESCRIPTION
While using this package, I noticed that it errors out then you pass an odd number of parameters to xadd, when it shouldnt, i.e

```
redis.xadd(
          'stream',
          'MAXLEN',
          '~',
          '50',
          '*',
          'reading',
          '{"key": "value"}'
        )
```
I believe the problem is unique to the "~" character, allowing for an odd number of params - reflected in this logic:

```
(args.includes('~') ? args.length < 4 : args.length % 2 !== 0)
```

I have also included an extra test that covers this.

May be applicable to other issues: https://github.com/stipsan/ioredis-mock/issues/1039

