### PR TITLE
feat: Share context between Redis instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ The `ioredis-mock/jest` bundle inlines imports from `ioredis` that `ioredis-mock
 
 ### Pub/Sub channels
 
-We also support redis publish/subscribe channels (just like [ioredis](https://redis.io/topics/pubsub)).
-Like ioredis, you need two clients:
+We also support redis [publish/subscribe](https://redis.io/topics/pubsub) channels.
+Like [ioredis](https://github.com/luin/ioredis#pubsub), you need two clients:
 
 ```js
 const Redis = require('ioredis-mock');

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ The `ioredis-mock/jest` bundle inlines imports from `ioredis` that `ioredis-mock
 
 ### Pub/Sub channels
 
-We also support redis publish/subscribe channels (just like [ioredis](<(https://redis.io/topics/pubsub)>)).
+We also support redis publish/subscribe channels (just like [ioredis](https://redis.io/topics/pubsub)).
 Like ioredis, you need two clients:
 
 ```js

--- a/test/commands/expire.js
+++ b/test/commands/expire.js
@@ -75,7 +75,7 @@ describe('expire', () => {
 
   it('should emit keyspace notification if configured', (done) => {
     const redis = new Redis({ notifyKeyspaceEvents: 'gK' }); // gK: generic Keyspace
-    const redisPubSub = redis.createConnectedClient();
+    const redisPubSub = redis.duplicate();
     redisPubSub.on('message', (channel, message) => {
       expect(channel).toBe('__keyspace@0__:foo');
       expect(message).toBe('expire');

--- a/test/commands/psubscribe.js
+++ b/test/commands/psubscribe.js
@@ -46,7 +46,7 @@ describe('psubscribe', () => {
 
   it('should allow multiple instances to subscribe to the same channel', () => {
     const redisOne = new Redis();
-    const redisTwo = redisOne.createConnectedClient();
+    const redisTwo = new Redis();
 
     return Promise.all([
       redisOne.psubscribe('first.*', 'second.*'),
@@ -66,7 +66,7 @@ describe('psubscribe', () => {
       redisOne.on('pmessage', promiseOneFulfill);
       redisTwo.on('pmessage', PromiseTwoFulfill);
 
-      redisOne.createConnectedClient().publish('first.test', 'blah');
+      redisOne.duplicate().publish('first.test', 'blah');
 
       return Promise.all([promiseOne, promiseTwo]);
     });

--- a/test/commands/publish.js
+++ b/test/commands/publish.js
@@ -10,7 +10,7 @@ describe('publish', () => {
 
   it('should return 1 when publishing with a single subscriber', () => {
     const redisPubSub = new Redis();
-    const redis2 = redisPubSub.createConnectedClient();
+    const redis2 = new Redis();
     redisPubSub.subscribe('emails');
     return redis2
       .publish('emails', 'clark@daily.planet')
@@ -19,7 +19,7 @@ describe('publish', () => {
 
   it('should publish a message, which can be received by a previous subscribe', (done) => {
     const redisPubSub = new Redis();
-    const redis2 = redisPubSub.createConnectedClient();
+    const redis2 = new Redis();
     redisPubSub.on('message', (channel, message) => {
       expect(channel).toBe('emails');
       expect(message).toBe('clark@daily.planet');
@@ -31,7 +31,7 @@ describe('publish', () => {
 
   it('should emit messageBuffer event when a Buffer message is published on a subscribed channel', (done) => {
     const redisPubSub = new Redis();
-    const redis2 = redisPubSub.createConnectedClient();
+    const redis2 = new Redis();
     const buffer = Buffer.alloc(8);
     redisPubSub.on('messageBuffer', (channel, message) => {
       expect(channel).toBe('emails');
@@ -44,7 +44,7 @@ describe('publish', () => {
 
   it('should return 1 when publishing with a single pattern subscriber', () => {
     const redisPubSub = new Redis();
-    const redis2 = redisPubSub.createConnectedClient();
+    const redis2 = new Redis();
     redisPubSub.psubscribe('emails.*');
     return redis2
       .publish('emails.urgent', 'clark@daily.planet')
@@ -53,7 +53,7 @@ describe('publish', () => {
 
   it('should publish a message, which can be received by a previous psubscribe', (done) => {
     const redisPubSub = new Redis();
-    const redis2 = redisPubSub.createConnectedClient();
+    const redis2 = new Redis();
     redisPubSub.on('pmessage', (pattern, channel, message) => {
       expect(pattern).toBe('emails.*');
       expect(channel).toBe('emails.urgent');
@@ -66,7 +66,7 @@ describe('publish', () => {
 
   it('should emit a pmessageBuffer event when a Buffer message is published matching a psubscribed pattern', (done) => {
     const redisPubSub = new Redis();
-    const redis2 = redisPubSub.createConnectedClient();
+    const redis2 = new Redis();
     const buffer = Buffer.alloc(0);
     redisPubSub.on('pmessageBuffer', (pattern, channel, message) => {
       expect(pattern).toBe('emails.*');

--- a/test/commands/punsubscribe.js
+++ b/test/commands/punsubscribe.js
@@ -39,7 +39,7 @@ describe('punsubscribe', () => {
 
   it('should unsubscribe only one instance when more than one is subscribed to a channel', () => {
     const redisOne = new Redis();
-    const redisTwo = redisOne.createConnectedClient();
+    const redisTwo = new Redis();
 
     return Promise.all([
       redisOne.psubscribe('first.*'),
@@ -56,7 +56,7 @@ describe('punsubscribe', () => {
 
         redisOne.on('pmessage', promiseFulfill);
 
-        redisOne.createConnectedClient().publish('first.test', 'TEST');
+        redisOne.duplicate().publish('first.test', 'TEST');
 
         return promise;
       });

--- a/test/commands/rename.js
+++ b/test/commands/rename.js
@@ -18,7 +18,7 @@ describe('rename', () => {
 
   it('should emit keyspace notifications if configured', (done) => {
     const redis = new Redis({ notifyKeyspaceEvents: 'gK' }); // gK: generic Keyspace
-    const redisPubSub = redis.createConnectedClient();
+    const redisPubSub = redis.duplicate();
     let messagesReceived = 0;
     redisPubSub.on('message', (channel, message) => {
       messagesReceived++;

--- a/test/commands/subscribe.js
+++ b/test/commands/subscribe.js
@@ -51,7 +51,7 @@ describe('subscribe', () => {
 
   it('should allow multiple instances to subscribe to the same channel', () => {
     const redisOne = new Redis();
-    const redisTwo = redisOne.createConnectedClient();
+    const redisTwo = new Redis();
 
     return Promise.all([
       redisOne.subscribe('first', 'second'),
@@ -71,7 +71,7 @@ describe('subscribe', () => {
       redisOne.on('message', promiseOneFulfill);
       redisTwo.on('message', PromiseTwoFulfill);
 
-      redisOne.createConnectedClient().publish('first', 'blah');
+      redisOne.duplicate().publish('first', 'blah');
 
       return Promise.all([promiseOne, promiseTwo]);
     });

--- a/test/commands/unsubscribe.js
+++ b/test/commands/unsubscribe.js
@@ -38,7 +38,7 @@ describe('unsubscribe', () => {
 
   it('should unsubscribe only one instance when more than one is subscribed to a channel', () => {
     const redisOne = new Redis();
-    const redisTwo = redisOne.createConnectedClient();
+    const redisTwo = new Redis();
 
     return Promise.all([
       redisOne.subscribe('first'),
@@ -55,7 +55,7 @@ describe('unsubscribe', () => {
 
         redisOne.on('message', promiseFulfill);
 
-        redisOne.createConnectedClient().publish('first', 'TEST');
+        redisOne.duplicate().publish('first', 'TEST');
 
         return promise;
       });
@@ -63,7 +63,7 @@ describe('unsubscribe', () => {
 
   it('should not alter parent instance when connected client unsubscribes', () => {
     const redisOne = new Redis();
-    const redisTwo = redisOne.createConnectedClient();
+    const redisTwo = new Redis();
     return redisOne
       .subscribe('first')
       .then(() => redisTwo.unsubscribe('first'))

--- a/test/keyspace-notifications.js
+++ b/test/keyspace-notifications.js
@@ -67,7 +67,7 @@ describe('parseKeyspaceEvents', () => {
 describe('keyspaceNotifications', () => {
   it('should appear when configured and the triggering event occurs', (done) => {
     const redis = new Redis({ notifyKeyspaceEvents: 'gK' }); // gK: generic keyspace
-    const redisPubSub = redis.createConnectedClient();
+    const redisPubSub = redis.duplicate();
     redisPubSub.on('message', (channel, message) => {
       expect(channel).toBe('__keyspace@0__:key');
       expect(message).toBe('del');
@@ -105,7 +105,7 @@ describe('keyspaceNotifications', () => {
 describe('keyeventNotifications', () => {
   it('should appear when configured and the triggering event occurs', (done) => {
     const redis = new Redis({ notifyKeyspaceEvents: 'gE' }); // gK: generic keyevent
-    const redisPubSub = redis.createConnectedClient();
+    const redisPubSub = redis.duplicate();
     redisPubSub.on('message', (channel, message) => {
       expect(channel).toBe('__keyevent@0__:del');
       expect(message).toBe('key');

--- a/test/multiple-mocks.js
+++ b/test/multiple-mocks.js
@@ -3,7 +3,7 @@ import Redis from 'ioredis';
 describe('multipleMocks', () => {
   it('should be possible to create a second IORedis client, which is working on shared data with the first client', () => {
     const client1 = new Redis();
-    const client2 = client1.createConnectedClient();
+    const client2 = new Redis();
     client1.hset('testing', 'test', '2').then(() => {
       client2.hget('testing', 'test').then((val) => expect(val).toBe('2'));
     });
@@ -11,7 +11,7 @@ describe('multipleMocks', () => {
 
   it('should be possible to create a second IORedis client, which is working on shared channels with the first client', (done) => {
     const client1 = new Redis();
-    const client2 = client1.createConnectedClient();
+    const client2 = new Redis();
     client1.on('message', (channel, message) => {
       expect(channel).toBe('channel');
       expect(message).toBe('hello');
@@ -31,7 +31,7 @@ describe('multipleMocks', () => {
 
       const connectedClients = [];
       for (let i = 0; i < 10; i++) {
-        const connectedClient = client.createConnectedClient();
+        const connectedClient = client.duplicate();
         connectedClients.push(connectedClient);
         connectedClient.subscribe(testChannel);
       }


### PR DESCRIPTION
The change in https://github.com/stipsan/ioredis-mock/pull/1110 should've been a major release, not a minor, to ensure we respect semver. This PR is the first step to rectify that mistake. Related to https://github.com/stipsan/ioredis-mock/issues/1113

# BREAKING CHANGE

Before v6, each instance of `ioredis-mock` lived in isolation:

```js
const Redis = require('ioredis-mock');
const redis1 = new Redis();
const redis2 = new Redis();
await redis1.set('foo', 'bar');
console.log(await redis1.get('foo'), await redis2.get('foo')); // 'bar', null
```

In v6 the [internals were rewritten](https://github.com/stipsan/ioredis-mock/pull/1110) to behave more like real life redis, if the host and port is the same, the context is now shared:

```js
const Redis = require('ioredis-mock');
const redis1 = new Redis();
const redis2 = new Redis();
const redis3 = new Redis({ port: 6380 }); // 6379 is the default port
await redis1.set('foo', 'bar');
console.log(
  await redis1.get('foo'), // 'bar'
  await redis2.get('foo'), // 'bar'
  await redis3.get('foo') // null
);
```

And since `ioredis-mock` now persist data between instances, you'll [likely](https://github.com/luin/ioredis/blob/8278ec0a435756c54ba4f98587aec1a913e8b7d3/test/helpers/global.ts#L8) need to run `flushall` between testing suites:

```js
const Redis = require('ioredis-mock');
afterEach((done) => {
  new Redis().flushall().then(() => done());
});
```

#### `createConnectedClient` is deprecated

Replace it with `.duplicate()` or use another `new Redis` instance.