### PR TITLE
feat: add options shorthand

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ In v6 the [internals were rewritten](https://github.com/stipsan/ioredis-mock/pul
 const Redis = require('ioredis-mock')
 const redis1 = new Redis()
 const redis2 = new Redis()
-const redis3 = new Redis({ port: 6380 }) // 6379 is the default port
+const redis3 = new Redis(6380) // 6379 is the default port
 
 await redis1.set('foo', 'bar')
 console.log(

--- a/test/integration/options-shorthand.js
+++ b/test/integration/options-shorthand.js
@@ -1,0 +1,129 @@
+import Redis from 'ioredis'
+
+describe('constructor options', () => {
+  it('new Redis()', async () => {
+    const client1 = new Redis({ host: 'localhost', port: '6379' })
+    const client2 = new Redis()
+    const client3 = new Redis({ keyPrefix: 'private:' })
+
+    await client1.set('foo', 'bar')
+
+    expect(await client1.get('foo')).toBe(await client2.get('foo'))
+    expect(await client1.get('foo')).not.toBe(await client3.get('foo'))
+
+    client1.disconnect()
+    client2.disconnect()
+    client3.disconnect()
+  })
+
+  it('new Redis(port, host, options)', async () => {
+    const client1 = new Redis({ keyPrefix: 'shared:' })
+    const client2 = new Redis(6379, 'localhost', { keyPrefix: 'shared:' })
+    const client3 = new Redis({ keyPrefix: 'private:' })
+
+    await client1.set('foo', 'bar')
+
+    expect(await client1.get('foo')).toBe(await client2.get('foo'))
+    expect(await client1.get('foo')).not.toBe(await client3.get('foo'))
+
+    client1.disconnect()
+    client2.disconnect()
+    client3.disconnect()
+  })
+
+  it('new Redis(url, options)', async () => {
+    const client1 = new Redis({ keyPrefix: 'shared:' })
+    const client2 = new Redis('//localhost:6379', { keyPrefix: 'shared:' })
+    const client3 = new Redis('redis://localhost:6379', {
+      keyPrefix: 'private:',
+    })
+
+    await client1.set('foo', 'bar')
+
+    expect(await client1.get('foo')).toBe(await client2.get('foo'))
+    expect(await client1.get('foo')).not.toBe(await client3.get('foo'))
+
+    client1.disconnect()
+    client2.disconnect()
+    client3.disconnect()
+  })
+
+  it('new Redis(port, options)', async () => {
+    const client1 = new Redis({ keyPrefix: 'shared:' })
+    const client2 = new Redis(6379, { keyPrefix: 'shared:' })
+    const client3 = new Redis({ keyPrefix: 'private:' })
+
+    await client1.set('foo', 'bar')
+
+    expect(await client1.get('foo')).toBe(await client2.get('foo'))
+    expect(await client1.get('foo')).not.toBe(await client3.get('foo'))
+
+    client1.disconnect()
+    client2.disconnect()
+    client3.disconnect()
+  })
+
+  it('new Redis(port, host, options)', async () => {
+    const client1 = new Redis({ keyPrefix: 'shared:' })
+    const client2 = new Redis(6379, 'localhost', { keyPrefix: 'shared:' })
+    const client3 = new Redis({ keyPrefix: 'private:' })
+
+    await client1.set('foo', 'bar')
+
+    expect(await client1.get('foo')).toBe(await client2.get('foo'))
+    expect(await client1.get('foo')).not.toBe(await client3.get('foo'))
+
+    client1.disconnect()
+    client2.disconnect()
+    client3.disconnect()
+  })
+
+  it('new Redis(options)', async () => {
+    const client1 = new Redis({ keyPrefix: 'shared:' })
+    const client2 = new Redis({
+      host: 'localhost',
+      port: 6379,
+      keyPrefix: 'shared:',
+    })
+    const client3 = new Redis({ keyPrefix: 'private:' })
+
+    await client1.set('foo', 'bar')
+
+    expect(await client1.get('foo')).toBe(await client2.get('foo'))
+    expect(await client1.get('foo')).not.toBe(await client3.get('foo'))
+
+    client1.disconnect()
+    client2.disconnect()
+    client3.disconnect()
+  })
+
+  it('new Redis(port)', async () => {
+    const client1 = new Redis()
+    const client2 = new Redis(6379)
+    const client3 = new Redis({ keyPrefix: 'private:' })
+
+    await client1.set('foo', 'bar')
+
+    expect(await client1.get('foo')).toBe(await client2.get('foo'))
+    expect(await client1.get('foo')).not.toBe(await client3.get('foo'))
+
+    client1.disconnect()
+    client2.disconnect()
+    client3.disconnect()
+  })
+
+  it('new Redis(url)', async () => {
+    const client1 = new Redis()
+    const client2 = new Redis('redis://localhost:6379/')
+    const client3 = new Redis({ keyPrefix: 'private:' })
+
+    await client1.set('foo', 'bar')
+
+    expect(await client1.get('foo')).toBe(await client2.get('foo'))
+    expect(await client1.get('foo')).not.toBe(await client3.get('foo'))
+
+    client1.disconnect()
+    client2.disconnect()
+    client3.disconnect()
+  })
+})


### PR DESCRIPTION
Fixes #1120

Constructor shorthands now supported:
- `new Redis(6379, 'localhost', { keyPrefix: 'shared:' })`
- `new Redis('//localhost:6379', { keyPrefix: 'shared:' })`
- `new Redis('redis://localhost:6379', { keyPrefix: 'private:' })`
- `new Redis(6379, { keyPrefix: 'shared:' })`
- `new Redis(6379)`
- `new Redis('redis://localhost:6379/')`