### PR TITLE
fix: Return table for HGETALL from custom Lua scripts

### DIFF
--- a/src/commands/defineCommand.js
+++ b/src/commands/defineCommand.js
@@ -50,6 +50,10 @@ const callToRedisCommand = vm =>
       const name = args[0].toLowerCase()
       const redisCmd = commands[name].bind(this)
       result = redisCmd(...args.slice(1))
+      // maintain original table format of HGETALL in Lua https://redis.io/commands/HGETALL
+      if (name === 'hgetall') {
+        result = [].concat(...Object.entries(result))
+      }
     } catch (err) {
       if (!returnError) {
         throw err

--- a/test/integration/commands/defineCommand.js
+++ b/test/integration/commands/defineCommand.js
@@ -32,6 +32,33 @@ describe('defineCommand', () => {
     redis.disconnect()
   })
 
+  it('should return a table/array for hgetall', async () => {
+    const luaCode = `
+        local rcall = redis.call
+        rcall("HSET", KEYS[1], ARGV[1], ARGV[2])
+        rcall("HSET", KEYS[1], ARGV[3], ARGV[4])
+        return rcall("HGETALL", KEYS[1])
+      `
+    const redis = new Redis()
+    const someKey = 'k'
+    const someField1 = 'f1'
+    const someField2 = 'f2'
+    const someVal1 = 'v1'
+    const someVal2 = 'v2'
+    const definition = { numberOfKeys: 1, lua: luaCode }
+
+    await redis.defineCommand('someCmd', definition)
+    const tableResponse = await redis.someCmd(
+      someKey,
+      someField1,
+      someVal1,
+      someField2,
+      someVal2
+    )
+    expect(tableResponse).toEqual([someField1, someVal1, someField2, someVal2])
+    redis.disconnect()
+  })
+
   it('should support custom commmands returning a table/array of table/array elements', async () => {
     const luaCode = 'return {{10}, {100, 200}, {}}'
     const redis = new Redis()


### PR DESCRIPTION
This commit fixes a bug that causes HGETALL commands in Lua
to fail with ioredis-mock.

Redis returns an array reply for HGETALL. ioredis and ioredis-mock
convert this response to a JS object.

When using custom Lua scripts with ioredis, however, HGETALL returns
and array-like table. With this change, HGETALL will also return an
array-like table from Lua with ioredis-mock.