### PR TITLE
feat: support ioredis v5

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "standard-as-callback": "^2.1.0"
   },
   "peerDependencies": {
-    "ioredis": "4.x"
+    "ioredis": "4.x || 5.x"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.8",

--- a/src/command.js
+++ b/src/command.js
@@ -1,7 +1,17 @@
-import IoredisCommand from 'ioredis/built/command'
 import asCallback from 'standard-as-callback'
 
 import promiseContainer from './promise-container'
+
+let IoredisCommand
+try {
+  // ioredis v4
+  // eslint-disable-next-line global-require, import/no-unresolved
+  IoredisCommand = require('ioredis/built/command').default
+} catch (err) {
+  // ioredis v5
+  // eslint-disable-next-line global-require, import/no-unresolved
+  IoredisCommand = require('ioredis/built/Command').default
+}
 
 export function isInSubscriberMode(RedisMock) {
   if (RedisMock.channels === undefined) {


### PR DESCRIPTION
Closes #1164

I don't have Linux so can't test in a case-sensitive environment 🤣.

Test plan:

1. Make sure tests pass with ioredis v4 and ioredis v5.