### PR TITLE
feat: Redis Cluster pass redisOptions in constuctor

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -253,8 +253,12 @@ class RedisMock extends EventEmitter {
 RedisMock.Command = Command
 
 RedisMock.Cluster = class RedisClusterMock extends RedisMock {
-  constructor(nodesOptions) {
-    super()
+  constructor(nodesOptions, clusterOptions) {
+    if (clusterOptions && clusterOptions.redisOptions) {
+      super(clusterOptions.redisOptions)
+    } else {
+      super()
+    }
     this.nodes = []
     nodesOptions.forEach(options => this.nodes.push(new RedisMock(options)))
   }

--- a/test/integration/cluster.js
+++ b/test/integration/cluster.js
@@ -3,12 +3,14 @@ import Redis from 'ioredis'
 describe('cluster', () => {
   it('can create instance', () => {
     const cluster = new Redis.Cluster(['redis://localhost:6379'])
+    expect(cluster.connected).toEqual(true)
     return expect(cluster instanceof Redis.Cluster).toBeTruthy()
   })
 
   it('can return correct number of nodes', () => {
     const nodes = ['redis://localhost:7001', 'redis://localhost:7002']
     const cluster = new Redis.Cluster(nodes)
+    expect(cluster.connected).toEqual(true)
     expect(cluster.nodes.length).toEqual(nodes.length)
     expect(
       cluster.nodes.every(node => {
@@ -19,6 +21,7 @@ describe('cluster', () => {
 
   it('can set and get', () => {
     const cluster = new Redis.Cluster([''])
+    expect(cluster.connected).toEqual(true)
     return cluster
       .set('k', 'v')
       .then(() => {
@@ -28,4 +31,12 @@ describe('cluster', () => {
         return expect(v).toEqual('v')
       })
   })
+
+  it('can pass redis options to redis mock', () => {
+    const nodes = [{host: 'localhost', port: 7001}]
+    const options = {redisOptions: {lazyConnect: true}}
+    const cluster = new Redis.Cluster(nodes, options)
+    expect(cluster.connected).toEqual(false)
+  })
+
 })


### PR DESCRIPTION
This PR extends the experimental cluster support by passing along provided
Redis options in the cluster constructor.

Somewhat related to https://github.com/stipsan/ioredis-mock/issues/359