### PR TITLE
feat: add support to ioredis 4.x or 5.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "example.js"
   ],
   "scripts": {
-    "build:browser.js": "esbuild src/index.js --bundle --format=esm --outfile=browser.js --define:process=undefined --define:global.process=undefined --define:process.env.FENGARICONF=undefined --define:global=window  --define:process.browser=true --define:process.nextTick=nextTickShim --define:process.hrtime=hrtimeShim --define:setImmediate=nextTickShim --inject:./browser-shims.js --minify-syntax --sourcemap",
+    "build:browser.js": "esbuild src/index.js --bundle --format=esm --outfile=browser.js --external:ioredis/built/Command --external:ioredis/built/command --define:process=undefined --define:global.process=undefined --define:process.env.FENGARICONF=undefined --define:global=window  --define:process.browser=true --define:process.nextTick=nextTickShim --define:process.hrtime=hrtimeShim --define:setImmediate=nextTickShim --inject:./browser-shims.js --minify-syntax --sourcemap",
     "build:lib": "npx rimraf lib && esbuild src/index.js --outfile=lib/index.js --platform=node --target=node12 --bundle --external:fengari --external:fengari-interop --external:redis-commands --external:standard-as-callback --external:ioredis --sourcemap --minify-syntax",
     "codeclimate": "codeclimate-test-reporter < ./coverage/lcov.info",
     "precoverage": "npx rimraf coverage && npx mkdirp coverage",
@@ -50,7 +50,7 @@
     "standard-as-callback": "^2.1.0"
   },
   "peerDependencies": {
-    "ioredis": "4.x"
+    "ioredis": "4.x || 5.x"
   },
   "devDependencies": {
     "@babel/cli": "^7.16.8",

--- a/src/command.js
+++ b/src/command.js
@@ -1,4 +1,3 @@
-import IoredisCommand from 'ioredis/built/command'
 import asCallback from 'standard-as-callback'
 
 import promiseContainer from './promise-container'
@@ -59,9 +58,24 @@ export function throwIfCommandIsNotAllowed(commandName, RedisMock) {
   throwIfNotConnected(commandName, RedisMock)
 }
 
+let memoizedIoredisCommand;
+
 export const Command = {
   // eslint-disable-next-line no-underscore-dangle
-  transformers: IoredisCommand._transformer,
+  get transformers () {
+      if (!memoizedIoredisCommand) {
+        try {
+          // eslint-disable-next-line global-require, import/no-unresolved
+          memoizedIoredisCommand = require('ioredis/built/Command'); // Attempt to load v5.x
+        } catch {
+          // eslint-disable-next-line global-require, import/no-unresolved
+          memoizedIoredisCommand = require('ioredis/built/command'); // Attempt to load v4.x
+        }
+      }
+
+      // eslint-disable-next-line no-underscore-dangle
+      return memoizedIoredisCommand.default._transformer;
+  },
   setArgumentTransformer: (name, func) => {
     Command.transformers.argument[name] = func
   },


### PR DESCRIPTION
Comparing v4 and v5 (https://github.com/luin/ioredis/compare/v4.28.5...v5.0.0-beta.1) we can see that the old `lib/command.js` has moved to `lib/Command.js`. This PR supports both versions by only loading the one available.

NOTE: I had to set both `ioredis/built/Command` and `ioredis/built/command` as [external](https://esbuild.github.io/api/#external) dependencies because we are not able to bundle it since we are not sure which one we have available (might be version 4 or 5).