### PR TITLE
fix(lua): Expose unpack to imitate redis's lua 5.1 support

### DIFF
--- a/src/commands/defineCommand.js
+++ b/src/commands/defineCommand.js
@@ -27,6 +27,7 @@ export const defineRedisObject = vm => fn => {
       end
       return val
     end
+    unpack = table.unpack
     redis.call = function(...)
         return repair(call(false, ...))
     end

--- a/test/integration/commands/eval.js
+++ b/test/integration/commands/eval.js
@@ -17,6 +17,17 @@ runTwinSuite('eval', (command, equals) => {
       expect(equals(retVal, 'hello')).toBe(true)
     })
 
+    it('should support unpack', async () => {
+      const luaScript = `
+          function sum(a, b)
+            return tonumber(a)+tonumber(b)
+          end
+          return sum(unpack(ARGV))`
+      const retVal = await redis[command](luaScript, 0, 2, 12)
+
+      expect(retVal).toEqual(14)
+    })
+
     it('should execute a lua script through eval and get the return value', () => {
       const NUMBER_OF_KEYS = 2
       const KEY1 = 'KEY1'


### PR DESCRIPTION
In lua 5.2, the global function unpack was moved to table.unpack.

closes #1193