### PR TITLE
fix: map batch length to length in pipeline

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -10,6 +10,12 @@ class Pipeline {
     this._transactions = 0
 
     this.copyCommands()
+
+    Object.defineProperty(this, 'length', {
+      get () {
+        return this.batch.length;
+      },
+    });
   }
 
   copyCommands() {

--- a/test/integration/multi.js
+++ b/test/integration/multi.js
@@ -15,6 +15,17 @@ describe('multi', () => {
     expect(redis.batch.batch[1]).toEqual(expect.any(Function))
   })
 
+  it('should map batch length to length in pipeline',() => {
+    const redis = new Redis()
+    const pipeline = redis.pipeline()
+
+    pipeline
+      .incr('user_next')
+      .incr('post_next');
+
+    expect(pipeline.length).toBe(2);
+  })
+
   it('allows for pipelining methods', () => {
     const redis = new Redis()
 


### PR DESCRIPTION
As mentioned in the issue https://github.com/stipsan/ioredis-mock/issues/1046 accessing the queue length of the pipeline is different in the mocked version. Therefore I propose mapping `this.batch.length` to `this.length` in the pipeline