### PR TITLE
fix: keep options as redis property

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -113,6 +113,7 @@ class RedisMock extends EventEmitter {
       this.connected = true
       emitConnectEvent(this)
     }
+    this.options = optionsWithDefault;
   }
 
   get channels() {


### PR DESCRIPTION
This is required because some libraries will access the `.options` of Redis. E.g. https://github.com/swarthy/redis-semaphore/blob/master/src/utils/index.ts#L12