### PR TITLE
feat: implement nodes method in cluster mock

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -251,8 +251,24 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
     } else {
       super()
     }
-    this.nodes = []
-    nodesOptions.forEach(options => this.nodes.push(new RedisMock(options)))
+    nodesOptions.forEach(options => this.nodes.all.push(new RedisMock(options)))
+  }
+  
+  private this.nodes = {
+    all: [],
+    master: [],
+    slave: [],
+  };
+  
+  public nodes(role = "all") {
+      if (role !== "all" && role !== "master" && role !== "slave") {
+          throw new Error(`Invalid role "${role}". Expected "all", "master" or "slave"`);
+      }
+      return this.getNodes(role);
+  }
+  
+  private getNodes(role = "all") {
+    return this.nodes['all'] // temporary return all until implemented slave and master logic
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -264,11 +264,7 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
       if (role !== "all" && role !== "master" && role !== "slave") {
           throw new Error(`Invalid role "${role}". Expected "all", "master" or "slave"`);
       }
-      return this.getNodes(role);
-  }
-  
-  private getNodes(role = "all") {
-    return this.nodes['all'] // temporary return all until implemented slave and master logic
+      return this.nodes['all']  // temporary return all until implemented slave and master logic
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -251,20 +251,20 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
     } else {
       super()
     }
-    nodesOptions.forEach(options => this.nodes.all.push(new RedisMock(options)))
+    nodesOptions.forEach(options => this.clusterNodes.all.push(new RedisMock(options)))
   }
   
-  nodes = {
+  clusterNodes = {
     all: [],
     master: [],
     slave: [],
   };
   
   nodes(role = "all") {
-      if (role !== "all" && role !== "master" && role !== "slave") {
+      if (role !== 'all' && role !== 'master' && role !== 'slave') {
           throw new Error(`Invalid role "${role}". Expected "all", "master" or "slave"`);
       }
-      return this.nodes['all']  // temporary return all until implemented slave and master logic
+      return this.clusterNodes['all']  // temporary return all until implemented slave and master logic
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -254,13 +254,13 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
     nodesOptions.forEach(options => this.nodes.all.push(new RedisMock(options)))
   }
   
-  private this.nodes = {
+  nodes = {
     all: [],
     master: [],
     slave: [],
   };
   
-  public nodes(role = "all") {
+  nodes(role = "all") {
       if (role !== "all" && role !== "master" && role !== "slave") {
           throw new Error(`Invalid role "${role}". Expected "all", "master" or "slave"`);
       }


### PR DESCRIPTION
In the `ioredis` package there is a `Cluster.nodes('all' | 'slave' | 'master')`  method which is not supported here.
I implemented a short solution with an option to get master and slave nodes in the future.