### PR TITLE
fix: change clusterNodes back to nodes

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -268,7 +268,7 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
         `Invalid role "${role}". Expected "all", "master" or "slave"`
       )
     }
-    return this.nodes['all'] // temporary return all until implemented slave and master logic
+    return this.nodes.all // temporary return all until implemented slave and master logic
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -252,11 +252,11 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
       super()
     }
     nodesOptions.forEach(options =>
-      this.clusterNodes.all.push(new RedisMock(options))
+      this.nodes.all.push(new RedisMock(options))
     )
   }
 
-  clusterNodes = {
+  nodes = {
     all: [],
     master: [],
     slave: [],
@@ -268,7 +268,7 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
         `Invalid role "${role}". Expected "all", "master" or "slave"`
       )
     }
-    return this.clusterNodes['all'] // temporary return all until implemented slave and master logic
+    return this.nodes['all'] // temporary return all until implemented slave and master logic
   }
 }
 

--- a/src/index.js
+++ b/src/index.js
@@ -252,11 +252,11 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
       super()
     }
     nodesOptions.forEach(options =>
-      this.nodes.all.push(new RedisMock(options))
+      this.clusterNodes.all.push(new RedisMock(options))
     )
   }
 
-  nodes = {
+  clusterNodes = {
     all: [],
     master: [],
     slave: [],
@@ -268,7 +268,7 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
         `Invalid role "${role}". Expected "all", "master" or "slave"`
       )
     }
-    return this.nodes.all // temporary return all until implemented slave and master logic
+    return this.clusterNodes.all // temporary return all until implemented slave and master logic
   }
 }
 

--- a/test/integration/cluster.js
+++ b/test/integration/cluster.js
@@ -11,8 +11,8 @@ describe('cluster', () => {
     const nodes = ['redis://localhost:7001', 'redis://localhost:7002']
     const cluster = new Redis.Cluster(nodes)
     expect(cluster.connected).toEqual(true)
-    expect(cluster.nodes.length).toEqual(nodes.length)
-    expect(cluster.nodes.every(node => node instanceof Redis)).toBeTruthy()
+    expect(cluster.nodes().length).toEqual(nodes.length)
+    expect(cluster.nodes().every(node => node instanceof Redis)).toBeTruthy()
   })
 
   it('can set and get', () => {


### PR DESCRIPTION
Change variable name back from clusterNodes to nodes.
This will revert a breaking change, also tests won't fail. 