### PR TITLE
fix(set): support optional "GET" parameter

### DIFF
--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -20,6 +20,11 @@ export function set(key, value, ...options) {
   if (nx && this.data.has(key)) return null
   if (xx && !this.data.has(key)) return null
 
+  let result = 'OK'
+  if (options.indexOf('GET') !== -1) {
+    result = this.data.has(key) ? this.data.get(key) : null
+  }
+
   this.data.set(key, value)
 
   const expireOptions = new Map(createGroupedArray(filteredOptions, 2))
@@ -31,7 +36,7 @@ export function set(key, value, ...options) {
     this.expires.delete(key)
   }
 
-  return 'OK'
+  return result
 }
 
 export function setBuffer(...args) {

--- a/test/integration/commands/set.js
+++ b/test/integration/commands/set.js
@@ -67,5 +67,23 @@ runTwinSuite('set', (command, equals) => {
       expect(await redis[command]('foo', 1, 'NX')).toBe(null)
       redis.disconnect()
     })
+
+    it('should return null if GET is specified and the key does not exist', async () => {
+      const redis = new Redis()
+
+      expect(await redis[command]('foo', 1, 'GET')).toBe(null)
+      redis.disconnect()
+    })
+
+    it('should return previous value if GET is specified and the key already exists', async () => {
+      const redis = new Redis({
+        data: {
+          foo: 'bar',
+        },
+      })
+
+      expect(equals(await redis[command]('foo', 1, 'GET'), 'bar')).toBe(true)
+      redis.disconnect()
+    })
   })
 })


### PR DESCRIPTION
Set allows for an optional parameter `"GET"`, which causes Redis to return the previous value of the key if it existed. This adds a conditional return value to the `set` command, which is `"OK"` if `"GET"` was not provided in the options and is key's previous value otherwise.