### PR TITLE
fix: make `hscan` return flat list of entries

### DIFF
--- a/src/commands-utils/scan-command.common.js
+++ b/src/commands-utils/scan-command.common.js
@@ -42,30 +42,33 @@ function getCountAndMatch(args) {
   return [count, matchPattern]
 }
 
-export function scanHelper(allKeysOrPairs, size, cursorStart, ...args) {
+// allKeysOrEntries and keysOrEntries are either:
+// - an array of keys: ['foo', 'bar']
+// - an array of entries: [['foo', 'value1'], ['bar', 'value2']]
+export function scanHelper(allKeysOrEntries, size, cursorStart, ...args) {
   const cursor = parseInt(cursorStart, 10)
   if (Number.isNaN(cursor)) {
     throw new Error('Cursor must be integer')
   }
   const [count, matchPattern] = getCountAndMatch(args)
   let nextCursor = cursor + count
-  const keysOrPairs = allKeysOrPairs.slice(cursor, nextCursor)
+  const keysOrEntries = allKeysOrEntries.slice(cursor, nextCursor)
 
   // Apply MATCH filtering _after_ getting number of keys
   if (matchPattern) {
     let i = 0
-    while (i < keysOrPairs.length)
-      if (!matchPattern(keysOrPairs[i])) {
-        keysOrPairs.splice(i, size)
+    while (i < keysOrEntries.length)
+      if (!matchPattern(keysOrEntries[i])) {
+        keysOrEntries.splice(i, size)
       } else {
         i += size
       }
   }
 
   // Return 0 when iteration is complete.
-  if (nextCursor >= allKeysOrPairs.length) {
+  if (nextCursor >= allKeysOrEntries.length) {
     nextCursor = 0
   }
 
-  return [String(nextCursor), keysOrPairs]
+  return [String(nextCursor), keysOrEntries]
 }

--- a/src/commands-utils/scan-command.common.js
+++ b/src/commands-utils/scan-command.common.js
@@ -43,8 +43,8 @@ function getCountAndMatch(args) {
 }
 
 // allKeysOrEntries and keysOrEntries are either:
-// - an array of keys: ['foo', 'bar']
-// - an array of entries: [['foo', 'value1'], ['bar', 'value2']]
+// - an array of keys: ['key1', 'key2']
+// - an array of entries: [['key1', 'value1'], ['key2', 'value2']]
 export function scanHelper(allKeysOrEntries, size, cursorStart, ...args) {
   const cursor = parseInt(cursorStart, 10)
   if (Number.isNaN(cursor)) {

--- a/src/commands-utils/scan-command.common.js
+++ b/src/commands-utils/scan-command.common.js
@@ -42,30 +42,30 @@ function getCountAndMatch(args) {
   return [count, matchPattern]
 }
 
-export function scanHelper(allKeys, size, cursorStart, ...args) {
+export function scanHelper(allKeysOrPairs, size, cursorStart, ...args) {
   const cursor = parseInt(cursorStart, 10)
   if (Number.isNaN(cursor)) {
     throw new Error('Cursor must be integer')
   }
   const [count, matchPattern] = getCountAndMatch(args)
   let nextCursor = cursor + count
-  const keys = allKeys.slice(cursor, nextCursor)
+  const keysOrPairs = allKeysOrPairs.slice(cursor, nextCursor)
 
   // Apply MATCH filtering _after_ getting number of keys
   if (matchPattern) {
     let i = 0
-    while (i < keys.length)
-      if (!matchPattern(keys[i])) {
-        keys.splice(i, size)
+    while (i < keysOrPairs.length)
+      if (!matchPattern(keysOrPairs[i])) {
+        keysOrPairs.splice(i, size)
       } else {
         i += size
       }
   }
 
   // Return 0 when iteration is complete.
-  if (nextCursor >= allKeys.length) {
+  if (nextCursor >= allKeysOrPairs.length) {
     nextCursor = 0
   }
 
-  return [String(nextCursor), keys]
+  return [String(nextCursor), keysOrPairs]
 }

--- a/src/commands/hscan.js
+++ b/src/commands/hscan.js
@@ -6,8 +6,8 @@ export function hscan(key, cursor, ...args) {
     return ['0', []]
   }
   const entries = Object.entries(this.data.get(key))
-  const [cur, pairs] = scanHelper(entries, 1, cursor, ...args)
-  return [cur, pairs.flat()]
+  const [cur, scannedEntries] = scanHelper(entries, 1, cursor, ...args)
+  return [cur, scannedEntries.flat()]
 }
 
 export function hscanBuffer(...args) {

--- a/src/commands/hscan.js
+++ b/src/commands/hscan.js
@@ -5,8 +5,9 @@ export function hscan(key, cursor, ...args) {
   if (!this.data.has(key)) {
     return ['0', []]
   }
-  const hKeys = Object.keys(this.data.get(key))
-  return scanHelper(hKeys, 1, cursor, ...args)
+  const entries = Object.entries(this.data.get(key))
+  const [cur, pairs] = scanHelper(entries, 1, cursor, ...args)
+  return [cur, pairs.flat()]
 }
 
 export function hscanBuffer(...args) {

--- a/test/integration/commands/hscan.js
+++ b/test/integration/commands/hscan.js
@@ -6,8 +6,8 @@ describe('hscan', () => {
     redis.disconnect()
   })
 
-  const keysToPairs = keys => keys.flatMap(key => [key, `${key}v`]);
-  const createHashSet = keys => Object.fromEntries(keys.map(key => [key, `${key}v`]));
+  const keysToPairs = keys => keys.flatMap(key => [key, `${key}v`])
+  const createHashSet = keys => Object.fromEntries(keys.map(key => [key, `${key}v`]))
 
   it('should return null array if hset does not exist', () => {
     return redis.hscan('key', 0).then(result => {

--- a/test/integration/commands/hscan.js
+++ b/test/integration/commands/hscan.js
@@ -6,7 +6,7 @@ describe('hscan', () => {
     redis.disconnect()
   })
 
-  const keysToPairs = keys => keys.flatMap(key => [key, `${key}v`])
+  const keysToFlatEntries = keys => keys.flatMap(key => [key, `${key}v`])
   const createHashSet = keys => Object.fromEntries(keys.map(key => [key, `${key}v`]))
 
   it('should return null array if hset does not exist', () => {
@@ -26,7 +26,7 @@ describe('hscan', () => {
 
     return redis.hscan('hset', 0).then(result => {
       expect(result[0]).toBe('0')
-      expect(result[1]).toEqual(keysToPairs(['foo', 'bar', 'baz']))
+      expect(result[1]).toEqual(keysToFlatEntries(['foo', 'bar', 'baz']))
     })
   })
 
@@ -42,7 +42,7 @@ describe('hscan', () => {
 
       return redis.hscan('hset', 0, 'MATCH', 'foo*').then(result => {
         expect(result[0]).toBe('0')
-        expect(result[1]).toEqual(keysToPairs(['foo0', 'foo1', 'foo2']))
+        expect(result[1]).toEqual(keysToFlatEntries(['foo0', 'foo1', 'foo2']))
       })
     }
   )
@@ -61,12 +61,12 @@ describe('hscan', () => {
         .hscan('hset', 0, 'MATCH', 'foo*', 'COUNT', 1)
         .then(result => {
           expect(result[0]).toBe('1') // more elements left, this is why cursor is not 0
-          expect(result[1]).toEqual(keysToPairs(['foo0']))
+          expect(result[1]).toEqual(keysToFlatEntries(['foo0']))
           return redis.hscan('hset', result[0], 'MATCH', 'foo*', 'COUNT', 10)
         })
         .then(result2 => {
           expect(result2[0]).toBe('0')
-          expect(result2[1]).toEqual(keysToPairs(['foo1', 'foo2']))
+          expect(result2[1]).toEqual(keysToFlatEntries(['foo1', 'foo2']))
         })
     }
   )
@@ -85,12 +85,12 @@ describe('hscan', () => {
         .hscan('hset', 0, 'COUNT', 3)
         .then(result => {
           expect(result[0]).toBe('3')
-          expect(result[1]).toEqual(keysToPairs(['foo0', 'foo1', 'bar0']))
+          expect(result[1]).toEqual(keysToFlatEntries(['foo0', 'foo1', 'bar0']))
           return redis.hscan('hset', result[0], 'COUNT', 3)
         })
         .then(result2 => {
           expect(result2[0]).toBe('0')
-          expect(result2[1]).toEqual(keysToPairs(['bar1']))
+          expect(result2[1]).toEqual(keysToFlatEntries(['bar1']))
         })
     }
   )

--- a/test/integration/commands/hscan.js
+++ b/test/integration/commands/hscan.js
@@ -1,7 +1,4 @@
-import Chance from 'chance'
 import Redis from 'ioredis'
-
-const chance = new Chance()
 
 describe('hscan', () => {
   const redis = new Redis()
@@ -9,13 +6,8 @@ describe('hscan', () => {
     redis.disconnect()
   })
 
-  function createHashSet(keys) {
-    return keys.reduce((obj, key) => {
-      const res = obj
-      res[key] = chance.cc_type({ raw: true })
-      return res
-    }, {})
-  }
+  const keysToPairs = keys => keys.flatMap(key => [key, `${key}v`]);
+  const createHashSet = keys => Object.fromEntries(keys.map(key => [key, `${key}v`]));
 
   it('should return null array if hset does not exist', () => {
     return redis.hscan('key', 0).then(result => {
@@ -34,7 +26,7 @@ describe('hscan', () => {
 
     return redis.hscan('hset', 0).then(result => {
       expect(result[0]).toBe('0')
-      expect(result[1]).toEqual(['foo', 'bar', 'baz'])
+      expect(result[1]).toEqual(keysToPairs(['foo', 'bar', 'baz']))
     })
   })
 
@@ -50,7 +42,7 @@ describe('hscan', () => {
 
       return redis.hscan('hset', 0, 'MATCH', 'foo*').then(result => {
         expect(result[0]).toBe('0')
-        expect(result[1]).toEqual(['foo0', 'foo1', 'foo2'])
+        expect(result[1]).toEqual(keysToPairs(['foo0', 'foo1', 'foo2']))
       })
     }
   )
@@ -69,12 +61,12 @@ describe('hscan', () => {
         .hscan('hset', 0, 'MATCH', 'foo*', 'COUNT', 1)
         .then(result => {
           expect(result[0]).toBe('1') // more elements left, this is why cursor is not 0
-          expect(result[1]).toEqual(['foo0'])
+          expect(result[1]).toEqual(keysToPairs(['foo0']))
           return redis.hscan('hset', result[0], 'MATCH', 'foo*', 'COUNT', 10)
         })
         .then(result2 => {
           expect(result2[0]).toBe('0')
-          expect(result2[1]).toEqual(['foo1', 'foo2'])
+          expect(result2[1]).toEqual(keysToPairs(['foo1', 'foo2']))
         })
     }
   )
@@ -93,12 +85,12 @@ describe('hscan', () => {
         .hscan('hset', 0, 'COUNT', 3)
         .then(result => {
           expect(result[0]).toBe('3')
-          expect(result[1]).toEqual(['foo0', 'foo1', 'bar0'])
+          expect(result[1]).toEqual(keysToPairs(['foo0', 'foo1', 'bar0']))
           return redis.hscan('hset', result[0], 'COUNT', 3)
         })
         .then(result2 => {
           expect(result2[0]).toBe('0')
-          expect(result2[1]).toEqual(['bar1'])
+          expect(result2[1]).toEqual(keysToPairs(['bar1']))
         })
     }
   )

--- a/test/integration/commands/hscanStream.js
+++ b/test/integration/commands/hscanStream.js
@@ -1,6 +1,5 @@
 import Chance from 'chance'
 import Redis from 'ioredis'
-import zipObject from 'lodash.zipobject'
 import { ObjectWritableMock } from 'stream-mock'
 
 const chance = new Chance()
@@ -8,8 +7,9 @@ const chance = new Chance()
 // @TODO Rewrite test suite so it runs on a real Redis instance
 ;(process.env.IS_E2E ? describe.skip : describe)('hscanStream', () => {
   let writable
-  const randomCCType = () => chance.cc_type({ raw: true })
-  const createHashSet = keys => zipObject(keys, keys.map(randomCCType))
+
+  const keysToPairs = keys => keys.flatMap(key => [key, `${key}v`]);
+  const createHashSet = keys => Object.fromEntries(keys.map(key => [key, `${key}v`]));
 
   beforeEach(() => {
     writable = new ObjectWritableMock()
@@ -39,7 +39,7 @@ const chance = new Chance()
     stream.pipe(writable)
     writable.on('finish', () => {
       // Then
-      expect([].concat(...writable.data)).toEqual(['foo', 'bar'])
+      expect([].concat(...writable.data)).toEqual(keysToPairs(['foo', 'bar']))
       done()
     })
   })
@@ -55,7 +55,7 @@ const chance = new Chance()
     writable.on('finish', () => {
       // Then
       expect(writable.data.length).toEqual(Math.ceil(keys.length / count))
-      expect([].concat(...writable.data)).toEqual(keys)
+      expect([].concat(...writable.data)).toEqual(keys.flatMap(key => [key, `${key}v`]))
       done()
     })
   })
@@ -72,7 +72,7 @@ const chance = new Chance()
     stream.pipe(writable)
     writable.on('finish', () => {
       // Then
-      expect([].concat(...writable.data)).toEqual(['foo0', 'foo1', 'foo2'])
+      expect([].concat(...writable.data)).toEqual(keysToPairs(['foo0', 'foo1', 'foo2']))
       done()
     })
   })
@@ -90,7 +90,7 @@ const chance = new Chance()
     writable.on('finish', () => {
       // Then
       expect(writable.data.length).toEqual(Math.ceil(3))
-      expect([].concat(...writable.data)).toEqual(['foo0', 'foo1', 'foo2'])
+      expect([].concat(...writable.data)).toEqual(keysToPairs(['foo0', 'foo1', 'foo2']))
       done()
     })
   })

--- a/test/integration/commands/hscanStream.js
+++ b/test/integration/commands/hscanStream.js
@@ -55,7 +55,7 @@ const chance = new Chance()
     writable.on('finish', () => {
       // Then
       expect(writable.data.length).toEqual(Math.ceil(keys.length / count))
-      expect([].concat(...writable.data)).toEqual(keys.flatMap(key => [key, `${key}v`]))
+      expect([].concat(...writable.data)).toEqual(keysToFlatEntries(keys))
       done()
     })
   })

--- a/test/integration/commands/hscanStream.js
+++ b/test/integration/commands/hscanStream.js
@@ -8,7 +8,7 @@ const chance = new Chance()
 ;(process.env.IS_E2E ? describe.skip : describe)('hscanStream', () => {
   let writable
 
-  const keysToPairs = keys => keys.flatMap(key => [key, `${key}v`])
+  const keysToFlatEntries = keys => keys.flatMap(key => [key, `${key}v`])
   const createHashSet = keys => Object.fromEntries(keys.map(key => [key, `${key}v`]))
 
   beforeEach(() => {
@@ -39,7 +39,7 @@ const chance = new Chance()
     stream.pipe(writable)
     writable.on('finish', () => {
       // Then
-      expect([].concat(...writable.data)).toEqual(keysToPairs(['foo', 'bar']))
+      expect([].concat(...writable.data)).toEqual(keysToFlatEntries(['foo', 'bar']))
       done()
     })
   })
@@ -72,7 +72,7 @@ const chance = new Chance()
     stream.pipe(writable)
     writable.on('finish', () => {
       // Then
-      expect([].concat(...writable.data)).toEqual(keysToPairs(['foo0', 'foo1', 'foo2']))
+      expect([].concat(...writable.data)).toEqual(keysToFlatEntries(['foo0', 'foo1', 'foo2']))
       done()
     })
   })
@@ -90,7 +90,7 @@ const chance = new Chance()
     writable.on('finish', () => {
       // Then
       expect(writable.data.length).toEqual(Math.ceil(3))
-      expect([].concat(...writable.data)).toEqual(keysToPairs(['foo0', 'foo1', 'foo2']))
+      expect([].concat(...writable.data)).toEqual(keysToFlatEntries(['foo0', 'foo1', 'foo2']))
       done()
     })
   })

--- a/test/integration/commands/hscanStream.js
+++ b/test/integration/commands/hscanStream.js
@@ -8,8 +8,8 @@ const chance = new Chance()
 ;(process.env.IS_E2E ? describe.skip : describe)('hscanStream', () => {
   let writable
 
-  const keysToPairs = keys => keys.flatMap(key => [key, `${key}v`]);
-  const createHashSet = keys => Object.fromEntries(keys.map(key => [key, `${key}v`]));
+  const keysToPairs = keys => keys.flatMap(key => [key, `${key}v`])
+  const createHashSet = keys => Object.fromEntries(keys.map(key => [key, `${key}v`]))
 
   beforeEach(() => {
     writable = new ObjectWritableMock()


### PR DESCRIPTION
Fixes: https://github.com/stipsan/ioredis-mock/issues/962
Ref: https://redis.io/commands/scan/#return-value

> [HSCAN](https://redis.io/commands/hscan) [returns an] array of elements contain two elements, a field and a value, for every returned element of the Hash.