### PR TITLE
fix: Make unsupported commands writable

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -235,7 +235,7 @@ class RedisMock extends EventEmitter {
               )}, please check the full list over mocked commands: ${docsLink}`
             )
           },
-          writable: false,
+          writable: true,
         })
       }
     })

--- a/test/functional/commands.js
+++ b/test/functional/commands.js
@@ -15,4 +15,10 @@ describe('commands', () => {
       `"Unsupported command: "debugBuffer", please check the full list over mocked commands: https://github.com/stipsan/ioredis-mock/blob/main/compat.md#supported-commands-"`
     )
   })
+
+  test('unsupported commands should be writable', () => {
+    const redis = new Redis()
+    expect(() => (redis.debug = () => 'DEBUG')).not.toThrow()
+    expect(redis.debug()).toEqual('DEBUG')
+  })
 })

--- a/test/functional/commands.js
+++ b/test/functional/commands.js
@@ -18,7 +18,9 @@ describe('commands', () => {
 
   test('unsupported commands should be writable', () => {
     const redis = new Redis()
-    expect(() => (redis.debug = () => 'DEBUG')).not.toThrow()
+    expect(() => {
+      redis.debug = () => 'DEBUG'
+    }).not.toThrow()
     expect(redis.debug()).toEqual('DEBUG')
   })
 })


### PR DESCRIPTION
This allows monkey patching unsupported functions.
Closes #1258