### PR TITLE
fix: backport map batch length to length in pipeline.js

### DIFF
--- a/src/pipeline.js
+++ b/src/pipeline.js
@@ -11,6 +11,12 @@ class Pipeline {
     this._transactions = 0
 
     this.copyCommands()
+
+    Object.defineProperty(this, 'length', {
+      get () {
+        return this.batch.length;
+      },
+    });
   }
 
   copyCommands() {

--- a/test/integration/multi.js
+++ b/test/integration/multi.js
@@ -15,6 +15,17 @@ describe('multi', () => {
     expect(redis.batch.batch[1]).toEqual(expect.any(Function))
   })
 
+  it('should map batch length to length in pipeline',() => {
+    const redis = new Redis()
+    const pipeline = redis.pipeline()
+
+    pipeline
+      .incr('user_next')
+      .incr('post_next');
+
+    expect(pipeline.length).toBe(2);
+  })
+
   it('allows for pipelining methods', () => {
     const redis = new Redis()
 


### PR DESCRIPTION
Would you consider backporting https://github.com/stipsan/ioredis-mock/pull/1201 to v7.x?

I'm using the lib and I'm not ready to upgrade to v8 yet.