### PR TITLE
fix: Backport rpoplpush should rotate the list when source and destintation are the same

### DIFF
--- a/src/commands/rpoplpush.js
+++ b/src/commands/rpoplpush.js
@@ -22,11 +22,18 @@ export function rpoplpush(source, destination) {
   const newSource = this.data.get(source)
   const item = newSource.pop()
 
-  const newDest = this.data.get(destination)
+  let newDest = newSource // Operate on the same list
+  if (source !== destination) {
+    // Operate on two different lists
+    newDest = this.data.get(destination)
+  }
+
   newDest.unshift(item)
 
   this.data.set(source, newSource)
-  this.data.set(destination, newDest)
+  if (newSource !== newDest) {
+    this.data.set(destination, newDest)
+  }
 
   return item
 }

--- a/test/integration/commands/rpoplpush.js
+++ b/test/integration/commands/rpoplpush.js
@@ -104,5 +104,19 @@ runTwinSuite('rpoplpush', (command, equals) => {
         return expect(err.message).toBe('Key bar does not contain a list')
       })
     })
+
+    it('should rotate the list if the source and destination are the same', async () => {
+      const redis = new Redis({
+        data: {
+          foo: ['1', '2'],
+        },
+      })
+
+      const result = await redis[command]('foo', 'foo', 'LEFT', 'RIGHT');
+      expect(result).toBe('2');
+
+      const list = await redis.lrange('foo', 0, -1)
+      expect(list).toEqual(['2', '1'])
+    })
   })
 })


### PR DESCRIPTION
Would you consider backporting https://github.com/stipsan/ioredis-mock/pull/1321 to v7.x?

I can't upgrade to v8 yet and I'm facing fix https://github.com/stipsan/ioredis-mock/issues/1320.