### PR TITLE
fix: handle enableOfflineQueue correctly when disconnected

### DIFF
--- a/src/command.js
+++ b/src/command.js
@@ -46,7 +46,7 @@ export function throwIfInSubscriberMode(commandName, RedisMock) {
 
 export function throwIfNotConnected(commandName, RedisMock) {
   if (isNotConnected(RedisMock)) {
-    if (commandName !== 'connect' && commandName !== 'defineCommand') {
+    if (commandName !== 'connect' && commandName !== 'defineCommand' && !RedisMock.options.enableOfflineQueue) {
       throw new Error(
         "Stream isn't writeable and enableOfflineQueue options is false"
       )

--- a/test/integration/commands/connect.js
+++ b/test/integration/commands/connect.js
@@ -62,4 +62,11 @@ describe('connect', () => {
       redis.disconnect()
     }
   })
+
+  it('should not throw if executing any command when not connected and using enableOfflineQueue as true', async () => {
+    const redis = new Redis({ lazyConnect: true, enableOfflineQueue: true })
+
+    await expect(redis.get('key')).resolves.not.toThrow()
+    redis.disconnect()
+  })
 })


### PR DESCRIPTION
Ensure `throwIfNotConnected` respects `enableOfflineQueue` option to avoid errors when offline.