### PR TITLE
chore: Allow only positive integers in expire

### DIFF
--- a/src/commands/expire.js
+++ b/src/commands/expire.js
@@ -1,6 +1,10 @@
 import { emitNotification } from '../keyspace-notifications'
 
 export function expire(key, seconds) {
+  if (!Number.isInteger(Number(seconds)) || seconds < 0) {
+    throw new Error('ERR value is not an integer or out of range')
+  }
+
   if (!this.data.has(key)) {
     return 0
   }


### PR DESCRIPTION
Redis only allows the use of positive integers.