### PR TITLE
fix: disconnect clusterNodes

### DIFF
--- a/.changeset/disconnect-cluster-nodes.md
+++ b/.changeset/disconnect-cluster-nodes.md
@@ -1,0 +1,5 @@
+---
+'ioredis-mock': patch
+---
+
+when the cluster disconnects, all nodes are disconnected.

--- a/src/index.js
+++ b/src/index.js
@@ -293,6 +293,13 @@ RedisMock.Cluster = class RedisClusterMock extends RedisMock {
     }
     return this.clusterNodes.all // temporary return all until implemented slave and master logic
   }
+
+  disconnect() {
+    super.disconnect();
+    this.clusterNodes.all.forEach(node =>
+      node.disconnect()
+    )
+  }
 }
 
 RedisMock.Pipeline = Pipeline

--- a/test/integration/cluster.js
+++ b/test/integration/cluster.js
@@ -34,4 +34,16 @@ describe('cluster', () => {
       expect(cluster.connected).toEqual(false)
     }
   )
+  ;(process.env.IS_E2E ? it.skip : it)(
+    'can disconnect cluster nodes',
+    () => {
+      const nodes = ['redis://localhost:7001', 'redis://localhost:7002']
+      const cluster = new Redis.Cluster(nodes)
+      expect(cluster.connected).toEqual(true)
+      expect(cluster.nodes().every(node => node.connected)).toBeTruthy()
+      cluster.disconnect();
+      expect(cluster.connected).toEqual(false)
+      expect(cluster.nodes().every(node => node.connected)).toBeFalsy()
+    }
+  )
 })


### PR DESCRIPTION
When the cluster was disconnected, the individual nodes did not disconnect.

Now, when the cluster disconnects, all nodes are disconnected as well.