### PR TITLE
fix: handle SET options case-insensitively

### DIFF
--- a/src/commands/set.js
+++ b/src/commands/set.js
@@ -10,11 +10,14 @@ function createGroupedArray(arr, groupSize) {
 }
 
 export function set(key, value, ...options) {
-  const nx = options.indexOf('NX') !== -1
-  const xx = options.indexOf('XX') !== -1
-  const get = options.indexOf('GET') !== -1
+  const normalizedOptions = options.map(option =>
+    typeof option === 'string' ? option.toUpperCase() : option
+  )
+  const nx = normalizedOptions.indexOf('NX') !== -1
+  const xx = normalizedOptions.indexOf('XX') !== -1
+  const get = normalizedOptions.indexOf('GET') !== -1
 
-  const filteredOptions = options.filter(
+  const filteredOptions = normalizedOptions.filter(
     option => option !== 'NX' && option !== 'XX'
   )
 

--- a/test/integration/commands/set.js
+++ b/test/integration/commands/set.js
@@ -40,6 +40,17 @@ runTwinSuite('set', (command, equals) => {
       redis.disconnect()
     })
 
+    it('should handle expiration options case-insensitively', async () => {
+      const redis = new Redis()
+
+      expect(equals(await redis[command]('foo', 'bar', 'ex', 10), 'OK')).toBe(
+        true
+      )
+      expect(await redis.get('foo')).toBe('bar')
+      expect(await redis.ttl('foo')).toBeGreaterThanOrEqual(1)
+      redis.disconnect()
+    })
+
     it('should set value and expire with PX', async () => {
       const redis = new Redis()
 


### PR DESCRIPTION
## Summary

- normalize supported `SET` option keywords before parsing them
- make lowercase options such as `ex` behave like their uppercase Redis equivalents
- cover lowercase expiration handling for both string and buffer reply variants

## Checks

- `./node_modules/.bin/jest --config jest.config.js test/integration/commands/set.js --runInBand` — current base: expected regression failure; patched: 34 passed in the clean network-off verifier
- `npm test -- --runInBand` — 1,471 source tests, 1,365 built integration tests, and 1,245 browser tests passed; Node and browser builds also passed in separate network-off validation
- targeted Prettier and ESLint checks passed

Fixes #416

---
AI assistance was used. This change was reviewed by Northset, and I accept responsibility for this submission.

<!-- northset-receipt:M-1031:start -->
### Verification

[Northset proof-of-pass receipt M-1031](https://northset-oss.github.io/verification-pilot/receipts/M-1031/)  
Contributor self-run; not maintainer verification.
<!-- northset-receipt:M-1031:end -->
